### PR TITLE
Add worktree reminders to Hive task tooling outputs.

### DIFF
--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -273,7 +273,7 @@ const plugin: Plugin = async (ctx) => {
           const feature = resolveFeature(explicitFeature);
           if (!feature) return "Error: No feature specified. Create a feature or provide feature param.";
           const folder = taskService.create(feature, name, order);
-          return `Manual task created: ${folder}`;
+          return `Manual task created: ${folder}\nReminder: start work with hive_exec_start to use its worktree, and ensure any subagents work in that worktree too.`;
         },
       }),
 
@@ -344,7 +344,7 @@ const plugin: Plugin = async (ctx) => {
 
           taskService.writeSpec(feature, task, specContent);
 
-          return `Worktree created at ${worktree.path}\nBranch: ${worktree.branch}\nBase commit: ${worktree.commit}\nSpec: ${task}/spec.md generated`;
+          return `Worktree created at ${worktree.path}\nBranch: ${worktree.branch}\nBase commit: ${worktree.commit}\nSpec: ${task}/spec.md generated\nReminder: do all work inside this worktree and ensure any subagents do the same.`;
         },
       }),
 

--- a/packages/vscode-hive/src/tools/exec.ts
+++ b/packages/vscode-hive/src/tools/exec.ts
@@ -29,7 +29,7 @@ export function getExecTools(workspaceRoot: string): ToolRegistration[] {
           success: true,
           worktreePath: worktree.path,
           branch: worktree.branch,
-          message: `Worktree created. Work in ${worktree.path}. When done, use hive_exec_complete.`,
+          message: `Worktree created. Work in ${worktree.path}. When done, use hive_exec_complete. Reminder: do all work inside this worktree and ensure any subagents do the same.`,
         });
       },
     },

--- a/packages/vscode-hive/src/tools/task.ts
+++ b/packages/vscode-hive/src/tools/task.ts
@@ -51,7 +51,7 @@ export function getTaskTools(workspaceRoot: string): ToolRegistration[] {
       invoke: async (input, _token) => {
         const { feature, name, order } = input as { feature: string; name: string; order?: number };
         const folder = taskService.create(feature, name, order);
-        return `Created task "${folder}" with status: pending`;
+        return `Created task "${folder}" with status: pending\nReminder: run hive_exec_start to work in its worktree, and ensure any subagents work in that worktree too.`;
       },
     },
     {


### PR DESCRIPTION
## Summary
- add worktree reminders to `hive_task_create` outputs
- add worktree reminders to `hive_exec_start` outputs
- align messaging across OpenCode and VS Code tool responses
## Testing
- not run (not requested)