### PR TITLE
fix: preserve plan section in spec.md by storing raw plan title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ npm-debug.log*
 # Environment
 .env
 .env.local
+.ignore
+tmp/
 
 # Hive runtime data
 .hive/

--- a/packages/hive-core/src/services/featureService.ts
+++ b/packages/hive-core/src/services/featureService.ts
@@ -141,6 +141,7 @@ export class FeatureService {
         name,
         status: status?.status || 'pending',
         origin: status?.origin || 'plan',
+        planTitle: status?.planTitle,
         summary: status?.summary,
       };
     });

--- a/packages/hive-core/src/services/taskService.ts
+++ b/packages/hive-core/src/services/taskService.ts
@@ -106,6 +106,7 @@ export class TaskService {
     const status: TaskStatus = {
       status: 'pending',
       origin: 'manual',
+      planTitle: name,
     };
     writeJson(getTaskStatusPath(this.projectRoot, featureName, folder), status);
 
@@ -119,6 +120,7 @@ export class TaskService {
     const status: TaskStatus = {
       status: 'pending',
       origin: 'plan',
+      planTitle: task.name,
     };
     writeJson(getTaskStatusPath(this.projectRoot, featureName, task.folder), status);
 
@@ -204,6 +206,7 @@ export class TaskService {
       name: taskFolder.replace(/^\d+-/, ''),
       status: status.status,
       origin: status.origin,
+      planTitle: status.planTitle,
       summary: status.summary,
     };
   }

--- a/packages/hive-core/src/types.ts
+++ b/packages/hive-core/src/types.ts
@@ -34,6 +34,7 @@ export interface SubtaskStatus {
 export interface TaskStatus {
   status: TaskStatusType;
   origin: TaskOrigin;
+  planTitle?: string;
   summary?: string;
   startedAt?: string;
   completedAt?: string;
@@ -71,6 +72,7 @@ export interface TaskInfo {
   name: string;
   status: TaskStatusType;
   origin: TaskOrigin;
+  planTitle?: string;
   summary?: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `hive_exec_start` was overwriting task `spec.md` with only context content, losing the original task definition from the plan.
## Problem

When task titles in `plan.md` contain punctuation (backticks, parentheses, `+`, etc.), the plan section regex fails to match because it uses the slugified folder name instead of the original title.
## Example

**Plan title:**
```
### 1. Add `variant` to Hive agent config
```

**Folder created:**

01-add-variant-to-hive-agent-config

**Regex was searching for:**

```
### 1. add-variant-to-hive-agent-config
```

**Result:** No match → plan section omitted → spec.md contains only context.

## Before (broken)

```
# Task: 01-add-variant-to-hive-agent-config
## Feature: agent-variants
## Context
## research
Goal: port capability from oh-my-opencode-slim...
```
(plan section missing, only context shown)

## After (fixed)

```
# Task: 01-add-variant-to-hive-agent-config
## Feature: agent-variants
## Plan Section
### 1. Add `variant` to Hive agent config
**What**:
- Extend `AgentModelConfig` to include optional `variant?: string`.
- Update `ConfigService.getAgentConfig` to return `variant`.
**Must NOT**:
- Change config file path.
...
## Context
## research
...
```
## Solution
1. **Store raw plan title** in `status.json` during task creation
2. **Use raw title for matching** in `hive_exec_start` instead of slugified folder name
3. **Add order-based fallback** (`### N.`) for backward compatibility with existing tasks
## Changes

```
| File | Change |
|------|--------|
| `packages/hive-core/src/types.ts` | Add `planTitle?: string` to `TaskStatus` and `TaskInfo` |
| `packages/hive-core/src/services/taskService.ts` | Store `planTitle` on task creation; expose in `get()` |
| `packages/hive-core/src/services/featureService.ts` | Include `planTitle` in task summaries |
| `packages/opencode-hive/src/index.ts` | Match using `planTitle` with order-based fallback |
```

### Backward Compatibility

- Existing tasks without `planTitle` fall back to order-based matching (`### 1.`, `### 2.`, etc.)
- No migration needed for existing `.hive` directories