### PR TITLE
Fix: Align Hive guidance with background task completion notifications

### DIFF
--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -715,7 +715,11 @@ background_task({
 \`\`\`
 
 After spawning:
-- Monitor with hive_worker_status
+- Wait for the completion notification (no polling required).
+- Use hive_worker_status only for spot checks or diagnosing stuck tasks.
+- Use background_output only if interim output is explicitly needed, or after the completion notification arrives.
+- After receiving the <system-reminder> with the worker task_id, call background_output({ task_id: "<id>", block: false }) to fetch the final result.
+- If you suspect notifications did not deliver, do a single hive_worker_status() spot check.
 - Handle blockers when worker exits
 - Merge completed work with hive_merge
 
@@ -946,7 +950,7 @@ Re-run with updated summary showing verification results.`;
               ? 'Use hive_exec_start(task, continueFrom: "blocked", decision: answer) to resume blocked workers'
               : workers.some(w => w.maybeStuck)
                 ? 'Some workers may be stuck. Use background_output({ task_id }) to check output, or abort with hive_exec_abort.'
-                : 'Workers in progress. Use hive_worker_status and background_output for live output.',
+                : 'Workers in progress. Wait for the completion notification (no polling required). Use hive_worker_status for spot checks; use background_output only if interim output is explicitly needed.',
           }, null, 2);
         },
       }),


### PR DESCRIPTION
# PR: Align Hive guidance with background task completion notifications

## Why

Hive already sends completion reminders to the parent session, but the tool guidance still nudges agents toward polling. This update aligns the guidance with the push model and locks it in with a smoke test.

## What Changed

- `hive_exec_start` instructions now say to wait for completion notifications, use `hive_worker_status` only for spot checks, and use `background_output` only when needed (with a concrete example).
- `hive_worker_status` default hint now discourages polling and reinforces notification-first flow.
- Plugin smoke test now initializes a git repo and asserts the guidance strings from both tools.

## Tests

- `bun test packages/opencode-hive/src/e2e/plugin-smoke.test.ts`
- `npm run build --workspaces`

## Manual Verification

Prompt for agent:

```text
Please validate the background-task guidance in Hive tools.

Steps:
1) Run hive_feature_create, hive_plan_write, hive_plan_approve, hive_tasks_sync.
2) Call hive_exec_start on the first task (do not call background_task).
3) Confirm the instructions contain:
   - "Wait for the completion notification (no polling required)."
   - "Use hive_worker_status only for spot checks or diagnosing stuck tasks."
   - "Use background_output only if interim output is explicitly needed, or after the completion notification arrives."
4) Call hive_worker_status for the same feature.
5) Confirm the hint contains:
   - "Wait for the completion notification"
   - "spot checks"

Report pass/fail with the exact strings you saw.
```
### Result

```
Validation Report: Background-Task Guidance
Step 3: hive_exec_start Instructions
| Required String | Status | Exact String Found |
|-----------------|--------|-------------------|
| "Wait for the completion notification (no polling required)." | ✅ PASS | "- Wait for the completion notification (no polling required)." |
| "Use hive_worker_status only for spot checks or diagnosing stuck tasks." | ✅ PASS | "- Use hive_worker_status only for spot checks or diagnosing stuck tasks." |
| "Use background_output only if interim output is explicitly needed, or after the completion notification arrives." | ✅ PASS | "- Use background_output only if interim output is explicitly needed, or after the completion notification arrives." |
Step 5: hive_worker_status Hint
| Required String | Status | Exact String Found |
|-----------------|--------|-------------------|
| "Wait for the completion notification" | ✅ PASS | "Wait for the completion notification (no polling required)." |
| "spot checks" | ✅ PASS | "Use hive_worker_status for spot checks;" |
Full hint received:
"Workers in progress. Wait for the completion notification (no polling required). Use hive_worker_status for spot checks; use background_output only if interim output is explicitly needed."
---
Final Result: ✅ ALL CHECKS PASS
All 5 required strings were found in their respective tool outputs.
```