### PR TITLE
fix: remove unnecessary opencode.json agent registration

### DIFF
--- a/packages/hive-core/src/services/configService.ts
+++ b/packages/hive-core/src/services/configService.ts
@@ -125,60 +125,6 @@ export class ConfigService {
   }
 
   /**
-   * Register Hive agents in OpenCode's opencode.json.
-   * This is required because OpenCode doesn't support dynamic agent registration via plugin hooks.
-   * Agents are written to ~/.config/opencode/opencode.json under the 'agent' key.
-   */
-  registerAgentsInOpenCode(agents: Record<string, {
-    model?: string;
-    temperature?: number;
-    description: string;
-    prompt: string;
-    hidden?: boolean;
-    permission?: Record<string, string>;
-  }>): void {
-    const homeDir = process.env.HOME || process.env.USERPROFILE || '';
-    const opencodePath = path.join(homeDir, '.config', 'opencode', 'opencode.json');
-    
-    try {
-      if (!fs.existsSync(opencodePath)) {
-        // No opencode.json, skip registration
-        return;
-      }
-
-      const raw = fs.readFileSync(opencodePath, 'utf-8');
-      
-      const config = JSON.parse(stripJsonComments(raw));
-      
-      // Initialize agent section if not exists
-      if (!config.agent) {
-        config.agent = {};
-      }
-
-       // Initialize agent section (no legacy cleanup)
-
-      // Merge in our agents (don't overwrite user customizations)
-      for (const [name, agentConfig] of Object.entries(agents)) {
-        if (!config.agent[name]) {
-          config.agent[name] = agentConfig;
-        } else {
-          // Preserve user's model/temperature overrides, but update prompt and description
-          config.agent[name] = {
-            ...agentConfig,
-            model: config.agent[name].model || agentConfig.model,
-            temperature: config.agent[name].temperature ?? agentConfig.temperature,
-          };
-        }
-      }
-
-      fs.writeFileSync(opencodePath, JSON.stringify(config, null, 2));
-    } catch (err) {
-      // Silent fail - don't break plugin if we can't write
-      console.error('[Hive] Failed to register agents in opencode.json:', err);
-    }
-  }
-
-  /**
    * Get agent-specific model config
    */
   getAgentConfig(

--- a/packages/opencode-hive/src/agents/permissions.test.ts
+++ b/packages/opencode-hive/src/agents/permissions.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it } from 'bun:test';
-import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import plugin from '../index';
 
@@ -61,58 +59,38 @@ function createStubClient(): unknown {
 
 describe('Agent permissions for background task delegation', () => {
   it('registers hive_background_* tools as allow for primary agents', async () => {
-    const originalHome = process.env.HOME;
-    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'hive-permissions-'));
+    const repoRoot = path.resolve(import.meta.dir, '..', '..', '..', '..');
 
-    try {
-      process.env.HOME = tempHome;
+    const ctx: PluginInput = {
+      directory: repoRoot,
+      worktree: repoRoot,
+      serverUrl: new URL('http://localhost:1'),
+      project: { id: 'test', worktree: repoRoot, time: { created: Date.now() } },
+      client: createStubClient(),
+      $: createStubShell(),
+    };
 
-      const opencodeDir = path.join(tempHome, '.config', 'opencode');
-      fs.mkdirSync(opencodeDir, { recursive: true });
-      const opencodePath = path.join(opencodeDir, 'opencode.json');
-      fs.writeFileSync(opencodePath, JSON.stringify({}, null, 2));
+    const hooks = await plugin(ctx as any);
+    
+    // Config hook returns the merged config - agents are registered via config hook, not file write
+    const opencodeConfig: { agent?: Record<string, { permission?: Record<string, string> }> } = {};
+    await hooks.config?.(opencodeConfig);
 
-      const repoRoot = path.resolve(import.meta.dir, '..', '..', '..', '..');
+    const hivePerm = opencodeConfig.agent?.['hive-master']?.permission;
+    const swarmPerm = opencodeConfig.agent?.['swarm-orchestrator']?.permission;
+    const architectPerm = opencodeConfig.agent?.['architect-planner']?.permission;
 
-      const ctx: PluginInput = {
-        directory: repoRoot,
-        worktree: repoRoot,
-        serverUrl: new URL('http://localhost:1'),
-        project: { id: 'test', worktree: repoRoot, time: { created: Date.now() } },
-        client: createStubClient(),
-        $: createStubShell(),
-      };
+    expect(hivePerm).toBeTruthy();
+    expect(swarmPerm).toBeTruthy();
+    expect(architectPerm).toBeTruthy();
 
-      const hooks = await plugin(ctx as any);
-      await hooks.config?.({});
-
-      const config = JSON.parse(fs.readFileSync(opencodePath, 'utf-8')) as {
-        agent?: Record<string, { permission?: Record<string, string> }>;
-      };
-
-      const hivePerm = config.agent?.['hive-master']?.permission;
-      const swarmPerm = config.agent?.['swarm-orchestrator']?.permission;
-      const architectPerm = config.agent?.['architect-planner']?.permission;
-
-      expect(hivePerm).toBeTruthy();
-      expect(swarmPerm).toBeTruthy();
-      expect(architectPerm).toBeTruthy();
-
-      for (const perm of [hivePerm!, swarmPerm!, architectPerm!]) {
-        expect(perm.hive_background_task).toBe('allow');
-        expect(perm.hive_background_output).toBe('allow');
-        expect(perm.hive_background_cancel).toBe('allow');
-      }
-
-      expect(architectPerm!.edit).toBe('deny');
-      expect(architectPerm!.task).toBe('deny');
-    } finally {
-      if (originalHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = originalHome;
-      }
-      fs.rmSync(tempHome, { recursive: true, force: true });
+    for (const perm of [hivePerm!, swarmPerm!, architectPerm!]) {
+      expect(perm.hive_background_task).toBe('allow');
+      expect(perm.hive_background_output).toBe('allow');
+      expect(perm.hive_background_cancel).toBe('allow');
     }
+
+    expect(architectPerm!.edit).toBe('deny');
+    expect(architectPerm!.task).toBe('deny');
   });
 });

--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -1500,10 +1500,7 @@ Make the requested changes, then call hive_request_review again.`;
         'hygienic-reviewer': hygienicConfig,
       };
 
-      // Register agents directly in opencode.json (required for Task tool to find them)
-      configService.registerAgentsInOpenCode(allAgents);
-
-      // Also merge into opencodeConfig.agent (in case config hook works in future)
+      // Merge agents into opencodeConfig.agent (config hook is sufficient for agent discovery)
       const configAgent = opencodeConfig.agent as Record<string, unknown> | undefined;
       if (!configAgent) {
         opencodeConfig.agent = allAgents;


### PR DESCRIPTION
# PR: Remove Unnecessary opencode.json Agent Registration

## Summary

Removes the workaround that wrote Hive agent definitions directly to `~/.config/opencode/opencode.json`. Testing confirmed the plugin's config hook is sufficient for agent discovery.

## Problem

The plugin was doing two things to register agents:
1. Merging agents into `opencodeConfig.agent` via the plugin config hook
2. Writing agents directly to `~/.config/opencode/opencode.json` as a workaround

The direct file write was added because the original comment stated: *"OpenCode doesn't support dynamic agent registration via plugin hooks."*

This caused:
- Mutation of the user's config file (bad practice)
- Duplication between `agent_hive.json` (Hive config) and `opencode.json` (injected agents)
- Potential conflicts if OpenCode reads its own config and sees agents it didn't define

## Investigation

Traced the code and tested whether the config hook approach works:

1. Commented out `configService.registerAgentsInOpenCode(allAgents)`
2. Spawned a `forager-worker` via `background_task` with `sync: true`
3. **Result**: Agent was discovered and executed successfully

This confirms the config hook is sufficient for agent discovery via `client.app.agents()`.

## Changes

- **Removed** `registerAgentsInOpenCode` function from `packages/hive-core/src/services/configService.ts`
- **Removed** call to `registerAgentsInOpenCode` from `packages/opencode-hive/src/index.ts`
- **Kept** the config hook merge which handles agent registration correctly

## Files Changed

| File | Change |
|------|--------|
| `packages/hive-core/src/services/configService.ts` | Removed 53-line `registerAgentsInOpenCode` function |
| `packages/opencode-hive/src/index.ts` | Removed call, updated comment |
| `packages/opencode-hive/src/agents/permissions.test.ts` | Updated to test config hook output instead of file write |

## Testing

- [x] `background_task` with `agent: "forager-worker"` works
- [x] All Hive agents visible in Task tool
- [x] `bun run build` passes for both packages

### Manual Testing

- Build this server of agent-hive.
- Delete opencode in .cache
- Clear opencode.json of the agent-hive agents
- Open opencode and see that all agent-hive primary agents can be cycled
- ask an agent to try run hive_background_task with a agent-hive agent
- Ask the agent to tell you all agents it can see and its description.

## Impact

- Users' `~/.config/opencode/opencode.json` will no longer be modified by the plugin
- Existing agent entries in `opencode.json` can be manually cleaned up (optional)
- No functional change to agent behavior

## Questions

- Im unsure if this was needed for something else I'm missing? I looked through to see if this was needed for anything else and couldnt find it.
- I think its better to not touch opencode.json if possibe?
- There is this issues about not being able to see agents https://github.com/NeuralNomadsAI/CodeNomad/issues/83 and https://github.com/NeuralNomadsAI/CodeNomad/issues/93 cause of secure mode maybe this is related if you are using external clients?
