### PR TITLE
docs: Consolidate Configuration Reference in Main README

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -15,21 +15,23 @@ PROBLEM  -> CONTEXT  -> EXECUTION -> REPORT
 .hive/                    <- Shared data (all clients)
 ├── features/             <- Feature-scoped work
 │   └── {feature}/
+│       ├── feature.json  <- Feature metadata and state
 │       ├── plan.md       <- Approved execution plan
-│       ├── status.json   <- Feature state (planning/approved/executing/done)
-│       ├── context/      <- Persistent knowledge files
+│       ├── tasks.json    <- Task list with status
+│       ├── contexts/     <- Persistent knowledge files
 │       └── tasks/        <- Individual task folders
 │           └── {task}/
-│               ├── status.json  <- Task state
-│               ├── spec.md      <- Task context and requirements
+│               ├── status.json      <- Task state
+│               ├── spec.md          <- Task context and requirements
 │               ├── worker-prompt.md <- Full worker prompt
-│               └── report.md    <- Execution summary and results
+│               └── report.md        <- Execution summary and results
 └── .worktrees/           <- Isolated git worktrees per task
     └── {feature}/{task}/ <- Full repo copy for safe execution
 
 packages/
+├── hive-core/            <- Shared logic (services, types, utils)
 ├── opencode-hive/        <- OpenCode plugin (planning, execution, tracking)
-└── vscode-hive/          <- VSCode extension (visualization, review, approval)
+└── vscode-hive/          <- VS Code extension (visualization, review, approval)
 ```
 
 ## Data Flow
@@ -169,16 +171,17 @@ Reorder plugins so agent-hive appears last. Restart OpenCode after changing.
 Hive uses file-based state with clear ownership boundaries:
 
 | File | Owner | Other Access |
-|------|-------|--------------|
-| `status.json` (feature) | Hive Master | VSCode (read-only) |
+|------|-------|--------------| 
+| `feature.json` | Hive Master | VS Code (read-only) |
+| `tasks.json` | Hive Master | VS Code (read-only) |
 | `status.json` (task) | Worker | Hive Master (read), Poller (read-only) |
-| `plan.md` | Hive Master | VSCode (read + comment) |
-| `comments.json` | VSCode | Hive Master (read-only) |
+| `plan.md` | Hive Master | VS Code (read + comment) |
+| `comments.json` | VS Code | Hive Master (read-only) |
 | `spec.md` | `hive_exec_start` | Worker (read-only) |
 | `report.md` | Worker | All (read-only) |
 | `BLOCKED` | Beekeeper | All (read-only, blocks operations) |
-| `PENDING_REVIEW` | Worker | VSCode (delete to respond) |
-| `REVIEW_RESULT` | VSCode | Worker (read-only) |
+| `PENDING_REVIEW` | Worker | VS Code (delete to respond) |
+| `REVIEW_RESULT` | VS Code | Worker (read-only) |
 
 ### Poller Constraints
 

--- a/docs/GITHUB-COPILOT-GUIDE.md
+++ b/docs/GITHUB-COPILOT-GUIDE.md
@@ -19,7 +19,7 @@ Create `.github/agents/Hive.agent.md` in your repository:
 ```markdown
 ---
 description: 'Plan-first feature development with isolated worktrees and persistent context.'
-tools: ['runSubagent', 'tctinh.vscode-hive/hiveFeatureCreate', 'tctinh.vscode-hive/hiveFeatureList', 'tctinh.vscode-hive/hiveFeatureComplete', 'tctinh.vscode-hive/hivePlanWrite', 'tctinh.vscode-hive/hivePlanRead', 'tctinh.vscode-hive/hivePlanApprove', 'tctinh.vscode-hive/hiveTasksSync', 'tctinh.vscode-hive/hiveTaskCreate', 'tctinh.vscode-hive/hiveTaskUpdate', 'tctinh.vscode-hive/hiveSubtaskCreate', 'tctinh.vscode-hive/hiveSubtaskUpdate', 'tctinh.vscode-hive/hiveSubtaskList', 'tctinh.vscode-hive/hiveSubtaskSpecWrite', 'tctinh.vscode-hive/hiveSubtaskReportWrite', 'tctinh.vscode-hive/hiveExecStart', 'tctinh.vscode-hive/hiveExecComplete', 'tctinh.vscode-hive/hiveExecAbort', 'tctinh.vscode-hive/hiveMerge', 'tctinh.vscode-hive/hiveWorktreeList', 'tctinh.vscode-hive/hiveContextWrite', 'tctinh.vscode-hive/hiveContextRead', 'tctinh.vscode-hive/hiveContextList', 'tctinh.vscode-hive/hiveSessionOpen', 'tctinh.vscode-hive/hiveSessionList']
+tools: ['runSubagent', 'tctinh.vscode-hive/hiveFeatureCreate', 'tctinh.vscode-hive/hiveFeatureList', 'tctinh.vscode-hive/hiveFeatureComplete', 'tctinh.vscode-hive/hivePlanWrite', 'tctinh.vscode-hive/hivePlanRead', 'tctinh.vscode-hive/hivePlanApprove', 'tctinh.vscode-hive/hiveTasksSync', 'tctinh.vscode-hive/hiveTaskCreate', 'tctinh.vscode-hive/hiveTaskUpdate', 'tctinh.vscode-hive/hiveExecStart', 'tctinh.vscode-hive/hiveExecComplete', 'tctinh.vscode-hive/hiveExecAbort', 'tctinh.vscode-hive/hiveMerge', 'tctinh.vscode-hive/hiveWorktreeList', 'tctinh.vscode-hive/hiveContextWrite', 'tctinh.vscode-hive/hiveStatus']
 ---
 
 # Hive Agent
@@ -69,16 +69,17 @@ Call featureCreate({ name: "my-feature" })
 
 ## Available Tools
 
+The VS Code extension provides these tools for GitHub Copilot:
+
 | Domain | Tools | Description |
 |--------|-------|-------------|
 | **Feature** | `featureCreate`, `featureList`, `featureComplete` | Create and manage features |
 | **Plan** | `planWrite`, `planRead`, `planApprove` | Write and review plans |
 | **Task** | `tasksSync`, `taskCreate`, `taskUpdate` | Generate and manage tasks |
-| **Subtask** | `subtaskCreate`, `subtaskUpdate`, `subtaskList`, `subtaskSpecWrite`, `subtaskReportWrite` | TDD workflow |
 | **Exec** | `execStart`, `execComplete`, `execAbort` | Work in isolated worktrees |
 | **Merge** | `merge`, `worktreeList` | Integrate completed work |
-| **Context** | `contextWrite`, `contextRead`, `contextList` | Persistent knowledge |
-| **Session** | `sessionOpen`, `sessionList` | Session management |
+| **Context** | `contextWrite` | Persistent knowledge |
+| **Status** | `status` | Get comprehensive feature status |
 
 ## Parallel Execution with runSubagent
 
@@ -103,7 +104,7 @@ Use #tool:runSubagent to delegate tasks:
 
 Use #tool:runSubagent to execute task "2-add-token-refresh":
 - Call execStart for the task
-- Read context with contextRead
+- Read context files from .hive/features/<name>/contexts/
 - Implement the feature
 - Call execComplete with summary
 - Do NOT call merge
@@ -119,7 +120,7 @@ Execute in parallel using #tool:runSubagent for each:
 
 Each sub-agent:
 - execStart for their task
-- contextRead for decisions
+- Read context files from .hive/
 - Do implementation
 - execComplete with summary
 - NOT merge (orchestrator decides)

--- a/packages/opencode-hive/README.md
+++ b/packages/opencode-hive/README.md
@@ -178,7 +178,7 @@ Hive uses a config file at `~/.config/opencode/agent_hive.json`. You can customi
 
 ### Per-Agent Skills
 
-Each agent can have specific skills enabled. If configured, only those skills are available:
+Each agent can have specific skills enabled. If configured, only those skills appear in `hive_skill()`:
 
 ```json
 {
@@ -205,7 +205,7 @@ Note: Wildcards like `["*"]` are **not supported** - use explicit skill names or
 
 ### Auto-load Skills
 
-Use `autoLoadSkills` to automatically inject skills into an agent's system prompt (in addition to any skills selected by the agent).
+Use `autoLoadSkills` to automatically inject skills into an agent's system prompt at session start.
 
 ```json
 {
@@ -220,6 +220,14 @@ Use `autoLoadSkills` to automatically inject skills into an agent's system promp
   }
 }
 ```
+
+**How `skills` and `autoLoadSkills` interact:**
+
+- `skills` controls what appears in `hive_skill()` — the agent can manually load these on demand
+- `autoLoadSkills` injects skills unconditionally at session start — no manual loading needed
+- These are **independent**: a skill can be auto-loaded but not appear in `hive_skill()`, or vice versa
+- Both only support Hive's built-in skills (not OpenCode base skills from the `skill()` tool)
+- User `autoLoadSkills` are **merged** with defaults (use global `disableSkills` to remove defaults)
 
 **Default auto-load skills by agent:**
 


### PR DESCRIPTION
# Consolidate Configuration Reference in Main README

## Summary

The main README was missing configuration details that existed only in `packages/opencode-hive/README.md` and `docs/`. Users had to hunt through multiple files to understand how to configure Agent Hive. This PR consolidates all configuration documentation into the main README and fixes stale content in docs.

## Changes

**README.md**
- Added complete configuration section with example JSON and schema reference
- Documented all core options: `agentMode`, `delegateMode`, `disableSkills`, `disableMcps`
- Added agent models table with all 6 agent types
- Listed all 8 skills with descriptions
- Documented per-agent skills and auto-load skills
- Added MCP research tools table with requirements
- Documented model variants configuration
- Fixed `.hive/` directory structure to match actual implementation

**docs/DESIGN.md**
- Fixed architecture diagram (`feature.json` not `status.json`, `contexts/` not `context/`)
- Updated Source of Truth table

**docs/GITHUB-COPILOT-GUIDE.md**
- Removed non-existent tools from frontmatter (subtasks, sessions, contextRead)
- Updated available tools table

**docs/Hive.agent.md**
- Removed stale subtask tools and TDD section
- Updated tool reference table
- Fixed context file paths

## Testing

No need. Just docs
