### PR TITLE
Forward variant to opencode agent registration (fixes variant use in opencode task() tool)

### DIFF
--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -1556,6 +1556,7 @@ Make the requested changes, then call hive_request_review again.`;
       const hiveAutoLoadedSkills = await buildAutoLoadedSkillsContent('hive-master', configService, directory);
       const hiveConfig = {
         model: hiveUserConfig.model,
+        variant: hiveUserConfig.variant,
         temperature: hiveUserConfig.temperature ?? 0.5,
         description: 'Hive (Hybrid) - Plans + orchestrates. Detects phase, loads skills on-demand.',
         prompt: QUEEN_BEE_PROMPT + hiveAutoLoadedSkills,
@@ -1574,6 +1575,7 @@ Make the requested changes, then call hive_request_review again.`;
       const architectAutoLoadedSkills = await buildAutoLoadedSkillsContent('architect-planner', configService, directory);
       const architectConfig = {
         model: architectUserConfig.model,
+        variant: architectUserConfig.variant,
         temperature: architectUserConfig.temperature ?? 0.7,
         description: 'Architect (Planner) - Plans features, interviews, writes plans. NEVER executes.',
         prompt: ARCHITECT_BEE_PROMPT + architectAutoLoadedSkills,
@@ -1595,6 +1597,7 @@ Make the requested changes, then call hive_request_review again.`;
       const swarmAutoLoadedSkills = await buildAutoLoadedSkillsContent('swarm-orchestrator', configService, directory);
       const swarmConfig = {
         model: swarmUserConfig.model,
+        variant: swarmUserConfig.variant,
         temperature: swarmUserConfig.temperature ?? 0.5,
         description: 'Swarm (Orchestrator) - Orchestrates execution. Delegates, spawns workers, verifies, merges.',
         prompt: SWARM_BEE_PROMPT + swarmAutoLoadedSkills,
@@ -1613,6 +1616,7 @@ Make the requested changes, then call hive_request_review again.`;
       const scoutAutoLoadedSkills = await buildAutoLoadedSkillsContent('scout-researcher', configService, directory);
       const scoutConfig = {
         model: scoutUserConfig.model,
+        variant: scoutUserConfig.variant,
         temperature: scoutUserConfig.temperature ?? 0.5,
         mode: 'subagent' as const,
         description: 'Scout (Explorer/Researcher/Retrieval) - Researches codebase + external docs/data.',
@@ -1633,6 +1637,7 @@ Make the requested changes, then call hive_request_review again.`;
       const foragerAutoLoadedSkills = await buildAutoLoadedSkillsContent('forager-worker', configService, directory);
       const foragerConfig = {
         model: foragerUserConfig.model,
+        variant: foragerUserConfig.variant,
         temperature: foragerUserConfig.temperature ?? 0.3,
         mode: 'subagent' as const,
         description: 'Forager (Worker/Coder) - Executes tasks directly in isolated worktrees. Never delegates.',
@@ -1651,6 +1656,7 @@ Make the requested changes, then call hive_request_review again.`;
       const hygienicAutoLoadedSkills = await buildAutoLoadedSkillsContent('hygienic-reviewer', configService, directory);
       const hygienicConfig = {
         model: hygienicUserConfig.model,
+        variant: hygienicUserConfig.variant,
         temperature: hygienicUserConfig.temperature ?? 0.3,
         mode: 'subagent' as const,
         description: 'Hygienic (Consultant/Reviewer/Debugger) - Reviews plan documentation quality. OKAY/REJECT verdict.',


### PR DESCRIPTION
# PR: Forward variant to opencode agent registration

## Problem

After this implementaion https://github.com/anomalyco/opencode/pull/11410

The `config` hook in `opencode-hive` reads `variant` from `ConfigService.getAgentConfig()` but does not include it in the agent config objects registered with opencode. The agent configs set `model` and `temperature` but omit `variant`.

This matters because opencode's built-in variant resolution in `createUserMessage` (`session/prompt.ts:831-838`) checks `agent.variant`:

```ts
const variant =
  input.variant ??
  (agent.variant &&
   agent.model &&
   model.providerID === agent.model.providerID &&
   model.modelID === agent.model.modelID
    ? agent.variant
    : undefined)
```

Since `agent.variant` was always `undefined`, this path never produced a value. The `chat.message` hook (introduced in the per-agent variant PR) was the only working path for variant injection.

## What changed

Added `variant: <agentUserConfig>.variant` to all six agent config objects in the `config` hook:

- `hiveConfig`
- `architectConfig`
- `swarmConfig`
- `scoutConfig`
- `foragerConfig`
- `hygienicConfig`

One line per agent. No other changes.

## How the two paths now interact

There are two paths for variant to reach the LLM request:

1. **Built-in resolution** (`prompt.ts:831`): opencode reads `agent.variant` and `agent.model`, checks they match the model in use, and sets `variant` on the message info. This now works because `agent.variant` is populated.

2. **`chat.message` hook** (`index.ts:417`): fires after built-in resolution. Checks `output.message.variant` and only sets it if currently `undefined`. Acts as a fallback for cases where the model guard in path 1 fails (e.g., model mismatch).

Both paths agree. Path 1 sets the value when model matches; the hook's `if (output.message.variant !== undefined) return` guard skips it. When model doesn't match, path 1 produces `undefined` and the hook fills it in.

## Scope

- `packages/opencode-hive/src/index.ts` only.
- No changes to `hive-core`, `vscode-hive`, tests, or schema.
- No upstream opencode changes.

## Verification

```bash
bun run build          # passes
bun -w opencode-hive test  # 306 pass, 0 fail
bun -w hive-core test      # 85 pass, 0 fail
```

### Manual verification

Requires both `agent_hive.json` and `opencode.json` configured with a variant-capable model.

`agent_hive.json`:
```json
{
  "agents": {
    "forager-worker": {
      "model": "anthropic/claude-sonnet-4-20250514",
      "variant": "high"
    }
  }
}
```

`opencode.json` (model must define the variant key):
```json
{
  "provider": {
    "anthropic": {
      "models": {
        "claude-sonnet-4-20250514": {
          "variants": {
            "high": {
              "thinking": { "type": "enabled", "budgetTokens": 16000 }
            }
          }
        }
      }
    }
  }
}
```

Prompt the hive-master agent:

> Use the task tool to spawn a forager-worker subagent. Have it read the file `opencode.json` in the project root and report back the first 5 lines.

Check opencode logs (`~/.local/share/opencode/log/`) for the forager-worker session's LLM request. The `thinking` options should be present in the provider options. As a negative control, remove `variant` from `agent_hive.json` and repeat -- the thinking block should disappear.
