### PR TITLE
docs: align philosophy notes with current implementation

### DIFF
--- a/packages/opencode-hive/src/e2e/opencode-runtime-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/opencode-runtime-smoke.test.ts
@@ -13,7 +13,7 @@ const EXPECTED_TOOLS = [
   "hive_plan_write",
   "hive_plan_read",
   "hive_tasks_sync",
-  "hive_exec_start",
+  "hive_worktree_create",
 ] as const;
 
 type DefaultModel = { providerID: string; modelID: string };


### PR DESCRIPTION
## Summary
- align `PHILOSOPHY.md` implementation status notes with the current codebase/tooling reality
- fix stale e2e smoke test expected tool from `hive_exec_start` to `hive_worktree_create`

## Verification
- `PATH=\"$HOME/.bun/bin:$PATH\" \"$HOME/.bun/bin/bun\" run --filter opencode-hive test -- src/e2e/opencode-runtime-smoke.test.ts`