### PR TITLE
fix: Enforce Terminal Commit Contract for Delegated Workers

### DIFF
--- a/packages/opencode-hive/docs/HIVE-TOOLS.md
+++ b/packages/opencode-hive/docs/HIVE-TOOLS.md
@@ -26,8 +26,18 @@
 | Tool | Purpose |
 |------|---------|
 | `hive_worktree_create` | Create worktree and begin work |
-| `hive_worktree_commit` | Commit changes, write report (does NOT merge) |
+| `hive_worktree_commit` | Commit changes, write report (does NOT merge), return JSON completion contract |
 | `hive_worktree_discard` | Discard changes, reset status |
+
+#### hive_worktree_commit output
+
+- Always returns JSON with control-flow fields:
+  - `ok`: whether the operation succeeded
+  - `terminal`: whether worker should stop (`true`) or continue (`false`)
+  - `status`: completion status (`completed`, `blocked`, `failed`, `partial`) or error/rejected state
+  - `taskState`: resulting persisted task state
+  - `nextAction`: explicit next step for worker/orchestrator
+- Non-terminal responses (for example `reason: "verification_required"`) require worker remediation and retry.
 
 #### hive_worktree_create output
 

--- a/packages/opencode-hive/src/agents/forager.ts
+++ b/packages/opencode-hive/src/agents/forager.ts
@@ -95,7 +95,13 @@ hive_worktree_commit({
 })
 \`\`\`
 
-**CRITICAL: After hive_worktree_commit, STOP IMMEDIATELY.**
+Then inspect the tool response fields:
+- If \`ok=true\` and \`terminal=true\`: stop and hand off to orchestrator
+- Otherwise: **DO NOT STOP**. Follow \`nextAction\`, remediate, and retry \`hive_worktree_commit\`
+
+**CRITICAL: Stop only on terminal commit result (ok=true and terminal=true).**
+If commit returns non-terminal (for example verification_required), DO NOT STOP.
+Follow nextAction, fix the issue, and call hive_worktree_commit again.
 
 **Blocked (need user decision):**
 \`\`\`
@@ -144,7 +150,8 @@ When sandbox mode is active, ALL bash commands automatically run inside a Docker
 - Exceed task scope
 - Modify plan file
 - Use \`task\` or \`hive_worktree_create\`
-- Continue after hive_worktree_commit
+- Continue after terminal hive_worktree_commit result
+- Stop after non-terminal commit result
 - Skip verification
 
 **Always:**

--- a/packages/opencode-hive/src/agents/hive.ts
+++ b/packages/opencode-hive/src/agents/hive.ts
@@ -192,8 +192,9 @@ hive_worktree_create({ task: "01-task-name" })  // Creates worktree + Forager
 
 1. \`task()\` is BLOCKING — when it returns, the worker is DONE
 2. Immediately call \`hive_status()\` to check the new task state and find next runnable tasks
-3. If task status is blocked: read blocker info → \`question()\` → user decision → resume with \`continueFrom: "blocked"\`
-4. Do NOT wait for notifications or poll — the result is already available when \`task()\` returns
+3. Invariant: the delegated task MUST transition out of \`in_progress\`; if still \`in_progress\`, treat it as non-terminal worker completion and re-run/resume worker with explicit instruction to resolve commit response and retry
+4. If task status is blocked: read blocker info → \`question()\` → user decision → resume with \`continueFrom: "blocked"\`
+5. Do NOT wait for notifications or poll — the result is already available when \`task()\` returns
 
 ### Failure Recovery
 

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -39,6 +39,10 @@ describe('Hive (Hybrid) prompt', () => {
       expect(QUEEN_BEE_PROMPT).toContain('task(');
       expect(QUEEN_BEE_PROMPT).toContain('scout-researcher');
     });
+
+    it('enforces post-delegation task state invariant', () => {
+      expect(QUEEN_BEE_PROMPT).toContain('MUST transition out of `in_progress`');
+    });
   });
 
   describe('turn termination and hard blocks', () => {
@@ -133,6 +137,10 @@ describe('Swarm (Orchestrator) prompt', () => {
       expect(SWARM_BEE_PROMPT).toContain('hive_status()');
     });
 
+    it('enforces delegated task state invariant', () => {
+      expect(SWARM_BEE_PROMPT).toContain('must not remain `in_progress`');
+    });
+
     it('includes task() guidance for research fan-out', () => {
       expect(SWARM_BEE_PROMPT).toContain('task() for research fan-out');
     });
@@ -159,6 +167,12 @@ describe('Forager (Worker/Coder) prompt', () => {
 
   it('contains completion checklist', () => {
     expect(FORAGER_BEE_PROMPT).toContain('Completion Checklist');
+  });
+
+  it('requires terminal commit result before stopping', () => {
+    expect(FORAGER_BEE_PROMPT).toContain('ok');
+    expect(FORAGER_BEE_PROMPT).toContain('terminal');
+    expect(FORAGER_BEE_PROMPT).toContain('DO NOT STOP');
   });
 
   it('adds resolve-before-blocking guidance', () => {

--- a/packages/opencode-hive/src/agents/swarm.ts
+++ b/packages/opencode-hive/src/agents/swarm.ts
@@ -65,6 +65,7 @@ hive_worktree_create({ task: "01-task-name" })
 **Delegation Guidance:**
 - \`task()\` is BLOCKING — returns when the worker is done
 - Call \`hive_status()\` immediately after to check new state and find next runnable tasks
+- Invariant: delegated task must not remain \`in_progress\`; if it does, treat as non-terminal completion and resume/retry worker with explicit commit-result handling
 - For parallel fan-out, issue multiple \`task()\` calls in the same message
 
 ## After Delegation - VERIFY

--- a/packages/opencode-hive/src/utils/worker-prompt.test.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.test.ts
@@ -156,6 +156,15 @@ UNIQUE_MARKER_12345
     expect(prompt).toContain('hive_worktree_commit');
   });
 
+  it('requires terminal commit result before stopping', () => {
+    const params = createTestParams();
+    const prompt = buildWorkerPrompt(params);
+
+    expect(prompt).toContain('ok=true and terminal=true');
+    expect(prompt).toContain('DO NOT STOP');
+    expect(prompt).toContain('result.nextAction');
+  });
+
   it('includes worktree restriction warning', () => {
     const params = createTestParams();
     const prompt = buildWorkerPrompt(params);

--- a/packages/opencode-hive/src/utils/worker-prompt.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.ts
@@ -155,8 +155,16 @@ hive_worktree_commit({
 })
 \`\`\`
 
-**CRITICAL: After calling hive_worktree_commit, you MUST STOP IMMEDIATELY.**
-Do NOT continue working. Do NOT respond further. Your session is DONE.
+Then inspect the tool response fields:
+- If \`ok=true\` and \`terminal=true\`: stop the session
+- Otherwise: **DO NOT STOP**. Follow \`nextAction\`, remediate, and retry \`hive_worktree_commit\`
+
+**CRITICAL: Stop only on terminal commit result (ok=true and terminal=true).**
+If commit returns non-terminal (for example verification_required), DO NOT STOP.
+Follow result.nextAction, fix the issue, and call hive_worktree_commit again.
+
+Only when commit result is terminal should you stop.
+Do NOT continue working after a terminal result. Do NOT respond further. Your session is DONE.
 The Hive Master will take over from here.
 
 **Summary Guidance** (used verbatim for downstream task context):


### PR DESCRIPTION
# PR: Enforce Terminal Commit Contract for Delegated Workers

## Summary

This PR fixes a contract gap between Forager workers and `hive_worktree_commit` by making completion semantics explicit and machine-readable.

Before this change, workers were told to stop immediately after calling `hive_worktree_commit`, but the tool could return a non-terminal rejection (for example missing verification evidence). That could leave tasks in `in_progress` with an apparently silent worker finish. This confuses the orchestrator greatly.

After this change:

- `hive_worktree_commit` always returns structured JSON
- workers stop only when the response is terminal (`ok=true`, `terminal=true`)
- orchestrators enforce a post-delegation invariant that tasks must transition out of `in_progress`

## Problem

The previous flow had conflicting rules:

1. Worker prompt: "call commit and stop immediately"
2. Commit tool: may reject completion and require follow-up

This mismatch caused ambiguous worker endings and required manual interpretation of task state.

## What Changed

### 1) Structured completion contract in `hive_worktree_commit`

`hive_worktree_commit` now always returns JSON with control-flow fields:

- `ok`
- `terminal`
- `status`
- `taskState`
- `nextAction`

Non-terminal outcomes (for example `verification_required`, `commit_failed`) return `ok: false`, `terminal: false`, with explicit next action.

Terminal outcomes (`completed`, `blocked`, `failed`, `partial`) return `ok: true`, `terminal: true`.

### 2) Worker completion logic updated

Forager and worker prompt guidance now requires inspecting commit response semantics:

- stop only on terminal response
- do not stop on non-terminal response
- follow `nextAction` and retry commit

### 3) Orchestrator invariant added

Hive and Swarm prompts now enforce that after blocking `task()` return, delegated task state must not remain `in_progress`.

If it remains `in_progress`, orchestrator treats it as non-terminal completion and resumes/retries worker with explicit commit-response handling.

### 4) Tests and docs

- Added e2e coverage for non-terminal reject and terminal success commit paths
- Added prompt assertions for terminal/non-terminal behavior
- Updated tool docs with the new JSON contract

## Files Updated

- `packages/opencode-hive/src/index.ts`
- `packages/opencode-hive/src/utils/worker-prompt.ts`
- `packages/opencode-hive/src/agents/forager.ts`
- `packages/opencode-hive/src/agents/hive.ts`
- `packages/opencode-hive/src/agents/swarm.ts`
- `packages/opencode-hive/src/agents/prompts.test.ts`
- `packages/opencode-hive/src/utils/worker-prompt.test.ts`
- `packages/opencode-hive/src/e2e/plugin-smoke.test.ts`
- `packages/opencode-hive/docs/HIVE-TOOLS.md`

## Validation Run

- `bun test src/agents/prompts.test.ts src/utils/worker-prompt.test.ts src/e2e/plugin-smoke.test.ts` (pass)
- `bun run build` in `packages/opencode-hive` (pass)
- `bun run test` in `packages/opencode-hive` has one unrelated pre-existing failure in `src/e2e/opencode-runtime-smoke.test.ts` expecting deprecated `hive_exec_start`

## Manual Validation

### Prompt to test

Use this prompt with `hive-master` (or `swarm-orchestrator`) to validate both non-terminal and terminal behavior:

```text
Create a feature named "manual-worker-commit-contract-test" with a one-task plan that modifies a small text file.
Approve plan, sync tasks, and start task execution.

During task completion, first call hive_worktree_commit(status: "completed") with a summary that does NOT include verification evidence.
Confirm the response is JSON with ok=false, terminal=false, reason="verification_required", and task remains in_progress.

Then run verification commands, call hive_worktree_commit(status: "completed") again with verification evidence in summary,
and confirm response is JSON with ok=true, terminal=true, status="completed", taskState="done".

Finally, run hive_status to verify task state and use hive_merge to integrate.
```

### Expected manual outcomes

1. First completion attempt is rejected non-terminally with clear `nextAction`.
2. Worker does not treat first response as terminal completion.
3. Second completion attempt is terminal and task transitions to `done`.
4. Orchestrator sees coherent task state via `hive_status()`.
