### PR TITLE
feat: isolate hive-helper merge recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ The extension watches your `.hive/` directory and displays the current state. Al
 
 | Package | Platform | Description |
 |---------|----------|-------------|
-| **[opencode-hive](https://www.npmjs.com/package/opencode-hive)** | npm | OpenCode plugin — 6 specialized bee agents, 15 tools, 11 skills |
+| **[opencode-hive](https://www.npmjs.com/package/opencode-hive)** | npm | OpenCode plugin — 7 specialized bee agents, 15 tools, 11 skills |
 | **[vscode-hive](https://marketplace.visualstudio.com/items?itemName=tctinh.vscode-hive)** | VS Code | Visual management — review, comment, approve |
 
 **Agent Selection:** Use `hive`, `architect`, or `swarm` as your primary agent. Use `@scout`, `@forager`, or `@hygienic` to mention subagents directly.

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ You: Clear visibility into everything ✅
 | **Swarm (Orchestrator)** 🐝 | Orchestrates execution, delegates to workers |
 | **Scout (Explorer/Researcher/Retrieval)** 🔍 | Explores codebase + external docs/data |
 | **Forager (Worker/Coder)** 🍯 | Executes tasks in isolated worktrees |
+| **Hive Helper** 🛠️ | Runtime-only merge recovery helper for isolated branch reconciliation |
 | **Hygienic (Consultant/Reviewer/Debugger)** 🧹 | Reviews plan quality, OKAY/REJECT verdict |
 
 ### Compaction-safe recovery path
@@ -383,6 +384,7 @@ This recovery model has a strict ownership boundary:
 Some notes:
 
 - Custom subagents derived from `forager-worker` are treated as task workers for compaction recovery.
+- `hive-helper` is treated as a runtime-only subagent for merge recovery; it does not appear in generated `.github/agents/` docs and does not appear in `packages/vscode-hive/src/generators/` in v1.
 - Custom subagents derived from `hygienic-reviewer` are treated as subagents.
 - One-recovery-attempt escalation means a primary or subagent session gets one normal directive replay cycle after compaction, then must escalate back to the parent/orchestrator instead of looping through repeated compact-and-replay retries.
 - The recovery prompt avoids telling agents to call broad status tools or re-scan the repository because that tends to recreate drift after compaction.

--- a/packages/hive-core/src/index.test.ts
+++ b/packages/hive-core/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getHivePath } from "./utils/paths";
+import { CUSTOM_AGENT_RESERVED_NAMES, getHivePath } from "./index";
 import { detectContext } from "./utils/detection";
 
 describe("hive-core", () => {
@@ -14,5 +14,9 @@ describe("hive-core", () => {
     expect(result.feature).toBe("feature-x");
     expect(result.task).toBe("01-task");
     expect(result.projectRoot).toBe("C:/repo");
+  });
+
+  it("keeps hive-helper reserved only once", () => {
+    expect(CUSTOM_AGENT_RESERVED_NAMES.filter((name) => name === 'hive-helper')).toHaveLength(1);
   });
 });

--- a/packages/hive-core/src/services/configService.test.ts
+++ b/packages/hive-core/src/services/configService.test.ts
@@ -34,6 +34,7 @@ describe("ConfigService defaults", () => {
     expect(Object.keys(config.agents ?? {}).sort()).toEqual([
       "architect-planner",
       "forager-worker",
+      "hive-helper",
       "hive-master",
       "hygienic-reviewer",
       "scout-researcher",
@@ -48,6 +49,11 @@ describe("ConfigService defaults", () => {
     expect(config.agents?.["swarm-orchestrator"]?.model).toBe(
       "github-copilot/claude-opus-4.5",
     );
+    expect(config.agents?.['hive-helper']).toEqual({
+      model: 'github-copilot/gpt-5.2-codex',
+      temperature: 0.3,
+      autoLoadSkills: [],
+    });
     expect(config.customAgents).toEqual({
       'forager-example-template': {
         baseAgent: 'forager-worker',
@@ -242,6 +248,30 @@ describe("ConfigService defaults", () => {
       "verification-before-completion",
       "custom-skill",
     ]);
+  });
+
+  it('keeps hive-helper autoLoadSkills empty even when user sets them', () => {
+    const service = new ConfigService();
+    const configPath = service.getPath();
+
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          agents: {
+            'hive-helper': {
+              autoLoadSkills: ['test-driven-development'],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const config = service.getAgentConfig('hive-helper');
+    expect(config.autoLoadSkills).toEqual([]);
   });
 
   it("removes autoLoadSkills via disableSkills", () => {

--- a/packages/hive-core/src/services/configService.ts
+++ b/packages/hive-core/src/services/configService.ts
@@ -156,11 +156,13 @@ export class ConfigService {
     if (this.isBuiltInAgent(agent)) {
       const agentConfig = config.agents?.[agent] ?? {};
       const defaultAutoLoadSkills = DEFAULT_HIVE_CONFIG.agents?.[agent]?.autoLoadSkills ?? [];
-      const effectiveAutoLoadSkills = this.resolveAutoLoadSkills(
-        defaultAutoLoadSkills,
-        agentConfig.autoLoadSkills ?? [],
-        this.isPlannerAgent(agent),
-      );
+      const effectiveAutoLoadSkills = agent === 'hive-helper'
+        ? defaultAutoLoadSkills
+        : this.resolveAutoLoadSkills(
+            defaultAutoLoadSkills,
+            agentConfig.autoLoadSkills ?? [],
+            this.isPlannerAgent(agent),
+          );
 
       return {
         ...agentConfig,

--- a/packages/hive-core/src/services/worktreeService.test.ts
+++ b/packages/hive-core/src/services/worktreeService.test.ts
@@ -80,6 +80,39 @@ async function createCommittedFixture(): Promise<TestFixture> {
   return fixture;
 }
 
+async function createConflictingFixture(): Promise<TestFixture> {
+  const fixture = await createFixture();
+
+  await fs.writeFile(path.join(fixture.worktreePath, 'tracked.txt'), 'task change\n', 'utf-8');
+  const taskCommit = await fixture.service.commitChanges(
+    fixture.feature,
+    fixture.task,
+    'chore: conflicting task change',
+  );
+  expect(taskCommit.committed).toBe(true);
+
+  await fixture.repoGit.checkout('main');
+  await fs.writeFile(path.join(fixture.repoPath, 'tracked.txt'), 'main change\n', 'utf-8');
+  await fixture.repoGit.add('tracked.txt');
+  await fixture.repoGit.commit('chore: conflicting main change');
+
+  return fixture;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function branchExists(git: SimpleGit, branchName: string): Promise<boolean> {
+  const branches = await git.branch();
+  return branches.all.includes(branchName);
+}
+
 async function readHeadBody(targetPath: string): Promise<string> {
   const git = simpleGit(targetPath);
   const body = await git.raw(["log", "-1", "--format=%B"]);
@@ -137,6 +170,13 @@ describe("WorktreeService merge and commit messages", () => {
     const result = await fixture.service.merge(fixture.feature, fixture.task, "merge", message);
 
     expect(result.success).toBe(true);
+    expect(result.strategy).toBe('merge');
+    expect(result.conflictState).toBe('none');
+    expect(result.cleanup).toEqual({
+      worktreeRemoved: false,
+      branchDeleted: false,
+      pruned: false,
+    });
     expect(await readHeadBody(fixture.repoPath)).toBe(message);
   });
 
@@ -147,7 +187,129 @@ describe("WorktreeService merge and commit messages", () => {
     const result = await fixture.service.merge(fixture.feature, fixture.task, "squash", message);
 
     expect(result.success).toBe(true);
+    expect(result.strategy).toBe('squash');
+    expect(result.conflictState).toBe('none');
+    expect(result.cleanup).toEqual({
+      worktreeRemoved: false,
+      branchDeleted: false,
+      pruned: false,
+    });
     expect(await readHeadBody(fixture.repoPath)).toBe(message);
+  });
+
+  it('returns helper-friendly merge details and preserves branch/worktree by default', async () => {
+    const fixture = await createCommittedFixture();
+
+    const result = await fixture.service.merge(fixture.feature, fixture.task, 'merge');
+
+    expect(result).toMatchObject({
+      success: true,
+      merged: true,
+      strategy: 'merge',
+      filesChanged: ['task-change.txt'],
+      conflicts: [],
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruned: false,
+      },
+    });
+    expect(typeof result.sha).toBe('string');
+    expect(await pathExists(fixture.worktreePath)).toBe(true);
+    expect(await branchExists(fixture.repoGit, 'hive/test-feature/01-test-task')).toBe(true);
+  });
+
+  it('removes the worktree but keeps the branch when cleanup is worktree', async () => {
+    const fixture = await createCommittedFixture();
+
+    const result = await fixture.service.merge(fixture.feature, fixture.task, 'merge', undefined, {
+      cleanup: 'worktree',
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      merged: true,
+      strategy: 'merge',
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: true,
+        branchDeleted: false,
+        pruned: true,
+      },
+    });
+    expect(await pathExists(fixture.worktreePath)).toBe(false);
+    expect(await branchExists(fixture.repoGit, 'hive/test-feature/01-test-task')).toBe(true);
+  });
+
+  it('removes the worktree and deletes the branch when cleanup is worktree+branch', async () => {
+    const fixture = await createCommittedFixture();
+
+    const result = await fixture.service.merge(fixture.feature, fixture.task, 'merge', undefined, {
+      cleanup: 'worktree+branch',
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      merged: true,
+      strategy: 'merge',
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: true,
+        branchDeleted: true,
+        pruned: true,
+      },
+    });
+    expect(await pathExists(fixture.worktreePath)).toBe(false);
+    expect(await branchExists(fixture.repoGit, 'hive/test-feature/01-test-task')).toBe(false);
+  });
+
+  it('aborts merge conflicts by default and reports the conflict state', async () => {
+    const fixture = await createConflictingFixture();
+
+    const result = await fixture.service.merge(fixture.feature, fixture.task, 'merge');
+
+    expect(result).toMatchObject({
+      success: false,
+      merged: false,
+      strategy: 'merge',
+      filesChanged: ['tracked.txt'],
+      conflicts: ['tracked.txt'],
+      conflictState: 'aborted',
+      cleanup: {
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruned: false,
+      },
+      error: 'Merge conflicts detected',
+    });
+    const status = await fixture.repoGit.status();
+    expect(status.conflicted).toEqual([]);
+  });
+
+  it('preserves merge conflicts when requested', async () => {
+    const fixture = await createConflictingFixture();
+
+    const result = await fixture.service.merge(fixture.feature, fixture.task, 'merge', undefined, {
+      preserveConflicts: true,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      merged: false,
+      strategy: 'merge',
+      filesChanged: ['tracked.txt'],
+      conflicts: ['tracked.txt'],
+      conflictState: 'preserved',
+      cleanup: {
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruned: false,
+      },
+      error: 'Merge conflicts detected',
+    });
+    const status = await fixture.repoGit.status();
+    expect(status.conflicted).toContain('tracked.txt');
   });
 
   it("rejects rebase plus custom message", async () => {
@@ -157,6 +319,15 @@ describe("WorktreeService merge and commit messages", () => {
       {
         success: false,
         merged: false,
+        strategy: 'rebase',
+        filesChanged: [],
+        conflicts: [],
+        conflictState: 'none',
+        cleanup: {
+          worktreeRemoved: false,
+          branchDeleted: false,
+          pruned: false,
+        },
         error: "Custom merge message is not supported for rebase strategy",
       },
     );

--- a/packages/hive-core/src/services/worktreeService.ts
+++ b/packages/hive-core/src/services/worktreeService.ts
@@ -31,12 +31,24 @@ export interface CommitResult {
   message?: string;
 }
 
+export interface MergeOptions {
+  preserveConflicts?: boolean;
+  cleanup?: 'none' | 'worktree' | 'worktree+branch';
+}
+
 export interface MergeResult {
   success: boolean;
   merged: boolean;
+  strategy: 'merge' | 'squash' | 'rebase';
   sha?: string;
-  filesChanged?: string[];
-  conflicts?: string[];
+  filesChanged: string[];
+  conflicts: string[];
+  conflictState: 'none' | 'aborted' | 'preserved';
+  cleanup: {
+    worktreeRemoved: boolean;
+    branchDeleted: boolean;
+    pruned: boolean;
+  };
   error?: string;
 }
 
@@ -299,19 +311,29 @@ export class WorktreeService {
     }
   }
 
-  async remove(feature: string, step: string, deleteBranch = false): Promise<void> {
+  async remove(
+    feature: string,
+    step: string,
+    deleteBranch = false,
+  ): Promise<{ worktreeRemoved: boolean; branchDeleted: boolean; pruned: boolean }> {
     const worktreePath = this.getWorktreePath(feature, step);
     const branchName = this.getBranchName(feature, step);
     const git = this.getGit();
+    let worktreeRemoved = false;
+    let branchDeleted = false;
+    let pruned = false;
 
     try {
       await git.raw(["worktree", "remove", worktreePath, "--force"]);
+      worktreeRemoved = true;
     } catch {
       await fs.rm(worktreePath, { recursive: true, force: true });
+      worktreeRemoved = true;
     }
 
     try {
       await git.raw(["worktree", "prune"]);
+      pruned = true;
     } catch {
       /* intentional */
     }
@@ -319,10 +341,13 @@ export class WorktreeService {
     if (deleteBranch) {
       try {
         await git.deleteLocalBranch(branchName, true);
+        branchDeleted = true;
       } catch {
         /* intentional */
       }
     }
+
+    return { worktreeRemoved, branchDeleted, pruned };
   }
 
   async list(feature?: string): Promise<WorktreeInfo[]> {
@@ -502,28 +527,53 @@ export class WorktreeService {
     step: string,
     strategy: "merge" | "squash" | "rebase" = "merge",
     message?: string,
+    options: MergeOptions = {},
   ): Promise<MergeResult> {
     const branchName = this.getBranchName(feature, step);
     const git = this.getGit();
+    const cleanupMode = options.cleanup ?? 'none';
+    const preserveConflicts = options.preserveConflicts ?? false;
+
+    const emptyCleanup = {
+      worktreeRemoved: false,
+      branchDeleted: false,
+      pruned: false,
+    };
 
     if (strategy === "rebase" && message) {
       return {
         success: false,
         merged: false,
+        strategy,
+        filesChanged: [],
+        conflicts: [],
+        conflictState: 'none',
+        cleanup: emptyCleanup,
         error: "Custom merge message is not supported for rebase strategy",
       };
     }
 
+    let filesChanged: string[] = [];
+
     try {
       const branches = await git.branch();
       if (!branches.all.includes(branchName)) {
-        return { success: false, merged: false, error: `Branch ${branchName} not found` };
+        return {
+          success: false,
+          merged: false,
+          strategy,
+          filesChanged: [],
+          conflicts: [],
+          conflictState: 'none',
+          cleanup: emptyCleanup,
+          error: `Branch ${branchName} not found`,
+        };
       }
 
       const currentBranch = branches.current;
 
       const diffStat = await git.diff([`${currentBranch}...${branchName}`, "--stat"]);
-      const filesChanged = diffStat
+      filesChanged = diffStat
         .split("\n")
         .filter(l => l.trim() && l.includes("|"))
         .map(l => l.split("|")[0].trim());
@@ -532,11 +582,18 @@ export class WorktreeService {
         await git.raw(["merge", "--squash", branchName]);
         const squashMessage = message || `hive: merge ${step} (squashed)`;
         const result = await git.commit(squashMessage);
+        const cleanup = cleanupMode === 'none'
+          ? emptyCleanup
+          : await this.remove(feature, step, cleanupMode === 'worktree+branch');
         return {
           success: true,
           merged: true,
+          strategy,
           sha: result.commit,
           filesChanged,
+          conflicts: [],
+          conflictState: 'none',
+          cleanup,
         };
       } else if (strategy === "rebase") {
         const commits = await git.log([`${currentBranch}..${branchName}`]);
@@ -545,43 +602,70 @@ export class WorktreeService {
           await git.raw(["cherry-pick", commit.hash]);
         }
         const head = (await git.revparse(["HEAD"])).trim();
+        const cleanup = cleanupMode === 'none'
+          ? emptyCleanup
+          : await this.remove(feature, step, cleanupMode === 'worktree+branch');
         return {
           success: true,
           merged: true,
+          strategy,
           sha: head,
           filesChanged,
+          conflicts: [],
+          conflictState: 'none',
+          cleanup,
         };
       } else {
         const mergeMessage = message || `hive: merge ${step}`;
         const result = await git.merge([branchName, "--no-ff", "-m", mergeMessage]);
         const head = (await git.revparse(["HEAD"])).trim();
+        const cleanup = cleanupMode === 'none'
+          ? emptyCleanup
+          : await this.remove(feature, step, cleanupMode === 'worktree+branch');
         return {
           success: true,
           merged: !result.failed,
+          strategy,
           sha: head,
           filesChanged,
           conflicts: result.conflicts?.map(c => c.file || String(c)) || [],
+          conflictState: 'none',
+          cleanup,
         };
       }
     } catch (error: unknown) {
       const err = error as { message?: string };
       
       if (err.message?.includes("CONFLICT") || err.message?.includes("conflict")) {
-        await git.raw(["merge", "--abort"]).catch(() => {});
-        await git.raw(["rebase", "--abort"]).catch(() => {});
-        await git.raw(["cherry-pick", "--abort"]).catch(() => {});
+        const conflicts = await this.getActiveConflictFiles(git, err.message || '');
+        const conflictState = preserveConflicts ? 'preserved' : 'aborted';
+
+        if (!preserveConflicts) {
+          await git.raw(["merge", "--abort"]).catch(() => {});
+          await git.raw(["rebase", "--abort"]).catch(() => {});
+          await git.raw(["cherry-pick", "--abort"]).catch(() => {});
+        }
         
         return {
           success: false,
           merged: false,
+          strategy,
+          filesChanged,
+          conflicts,
+          conflictState,
+          cleanup: emptyCleanup,
           error: "Merge conflicts detected",
-          conflicts: this.parseConflictsFromError(err.message || ""),
         };
       }
 
       return {
         success: false,
         merged: false,
+        strategy,
+        filesChanged,
+        conflicts: [],
+        conflictState: 'none',
+        cleanup: emptyCleanup,
         error: err.message || "Merge failed",
       };
     }
@@ -613,6 +697,19 @@ export class WorktreeService {
       }
     }
     return conflicts;
+  }
+
+  private async getActiveConflictFiles(git: SimpleGit, errorMessage: string): Promise<string[]> {
+    try {
+      const status = await git.status();
+      if (status.conflicted.length > 0) {
+        return [...new Set(status.conflicted)];
+      }
+    } catch {
+      /* intentional */
+    }
+
+    return this.parseConflictsFromError(errorMessage);
   }
 }
 

--- a/packages/hive-core/src/types.ts
+++ b/packages/hive-core/src/types.ts
@@ -209,6 +209,7 @@ export const BUILT_IN_AGENT_NAMES = [
   'swarm-orchestrator',
   'scout-researcher',
   'forager-worker',
+  'hive-helper',
   'hygienic-reviewer',
 ] as const;
 
@@ -225,6 +226,7 @@ export const CUSTOM_AGENT_RESERVED_NAMES = [
   'swarm',
   'scout',
   'forager',
+  'hive-helper',
   'hygienic',
   'receiver',
   'build',
@@ -271,6 +273,8 @@ export interface HiveConfig {
     'scout-researcher'?: AgentModelConfig;
     /** Forager Worker */
     'forager-worker'?: AgentModelConfig;
+    /** Hive Helper */
+    'hive-helper'?: AgentModelConfig;
     /** Hygienic Reviewer */
     'hygienic-reviewer'?: AgentModelConfig;
   };
@@ -292,6 +296,7 @@ export const DEFAULT_AGENT_MODELS = {
   'swarm-orchestrator': 'github-copilot/claude-opus-4.5',
   'scout-researcher': 'zai-coding-plan/glm-4.7',
   'forager-worker': 'github-copilot/gpt-5.2-codex',
+  'hive-helper': 'github-copilot/gpt-5.2-codex',
   'hygienic-reviewer': 'github-copilot/gpt-5.2-codex',
 } as const;
 
@@ -351,6 +356,11 @@ export const DEFAULT_HIVE_CONFIG: HiveConfig = {
       model: DEFAULT_AGENT_MODELS['forager-worker'],
       temperature: 0.3,
       autoLoadSkills: ['test-driven-development', 'verification-before-completion'],
+    },
+    'hive-helper': {
+      model: DEFAULT_AGENT_MODELS['hive-helper'],
+      temperature: 0.3,
+      autoLoadSkills: [],
     },
     'hygienic-reviewer': {
       model: DEFAULT_AGENT_MODELS['hygienic-reviewer'],

--- a/packages/hive-core/src/types.ts
+++ b/packages/hive-core/src/types.ts
@@ -226,7 +226,6 @@ export const CUSTOM_AGENT_RESERVED_NAMES = [
   'swarm',
   'scout',
   'forager',
-  'hive-helper',
   'hygienic',
   'receiver',
   'build',

--- a/packages/opencode-hive/README.md
+++ b/packages/opencode-hive/README.md
@@ -149,7 +149,7 @@ Manual tasks follow the same DAG model as plan-backed tasks:
 - Structured manual-task fields such as `goal`, `description`, `acceptanceCriteria`, `files`, and `references` are turned into worker-facing `spec.md` content.
 - If review feedback changes downstream sequencing or scope, update `plan.md` and run `hive_tasks_sync({ refreshPending: true })` so pending plan tasks pick up the new `dependsOn` graph and regenerated specs.
 
-This recovery path applies to the built-in `forager-worker` and custom agents derived from it, because they are the sessions most likely to be compacted mid-implementation.
+This recovery path applies to the built-in `forager-worker`, the runtime-only `hive-helper` merge recovery subagent, and custom agents derived from `forager-worker`. `hive-helper` is intentionally OpenCode runtime-only in v1: it does not appear in `.github/agents/` or `packages/vscode-hive/src/generators/`.
 
 ## Prompt Budgeting & Observability
 
@@ -304,6 +304,7 @@ Skill IDs must be safe directory names (no `/`, `\`, `..`, or `.`). Missing or i
 |-------|------------------------|
 | `hive-master` | `parallel-exploration` |
 | `forager-worker` | `test-driven-development`, `verification-before-completion` |
+| `hive-helper` | (none) |
 | `scout-researcher` | (none) |
 | `architect-planner` | `parallel-exploration` |
 | `swarm-orchestrator` | (none) |
@@ -360,6 +361,8 @@ Define plugin-only custom subagents with `customAgents`. Freshly initialized `ag
 
 - `baseAgent`: one of `forager-worker` or `hygienic-reviewer`
 - `description`: delegation guidance injected into primary planner/orchestrator prompts
+
+`hive-helper` is not a custom base agent. In v1 it stays runtime-only for isolated merge recovery and does not appear in `.github/agents/` or does not appear in `packages/vscode-hive/src/generators/`.
 
 Published example (validated by `src/e2e/custom-agent-docs-example.test.ts`):
 

--- a/packages/opencode-hive/README.md
+++ b/packages/opencode-hive/README.md
@@ -362,7 +362,7 @@ Define plugin-only custom subagents with `customAgents`. Freshly initialized `ag
 - `baseAgent`: one of `forager-worker` or `hygienic-reviewer`
 - `description`: delegation guidance injected into primary planner/orchestrator prompts
 
-`hive-helper` is not a custom base agent. In v1 it stays runtime-only for isolated merge recovery and does not appear in `.github/agents/` or does not appear in `packages/vscode-hive/src/generators/`.
+`hive-helper` is not a custom base agent. In v1 it stays runtime-only for isolated merge recovery and does not appear in `.github/agents/` and does not appear in `packages/vscode-hive/src/generators/`.
 
 Published example (validated by `src/e2e/custom-agent-docs-example.test.ts`):
 

--- a/packages/opencode-hive/docs/HIVE-TOOLS.md
+++ b/packages/opencode-hive/docs/HIVE-TOOLS.md
@@ -63,13 +63,32 @@
 ### Merge (1 tool)
 | Tool | Purpose |
 |------|---------|
-| `hive_merge` | Merge task branch (strategies: merge/squash/rebase); optional `message` for merge/squash |
+| `hive_merge` | Merge task branch (strategies: merge/squash/rebase); optional helper-friendly conflict preservation, cleanup, and `message` for merge/squash |
 
 #### hive_merge input notes
 
+- `preserveConflicts?: boolean` defaults to `false`; when `true`, merge conflicts stay in place for an isolated helper session instead of being auto-aborted.
+- `cleanup?: 'none' | 'worktree' | 'worktree+branch'` defaults to `'none'`; successful merges can keep the worktree, remove only the worktree, or remove the worktree and delete the task branch.
 - `message` is optional and applies to `merge`/`squash` strategies.
 - Do not provide `message` with `strategy: 'rebase'`.
 - Omit `message` (or pass `''`) to use default merge/squash message behavior.
+
+#### hive_merge output
+
+- Returns JSON with the shared merge result envelope plus a concise `message` string.
+- Shared result fields:
+  - `success`
+  - `merged`
+  - `strategy`
+  - `sha?`
+  - `filesChanged`
+  - `conflicts`
+  - `conflictState` (`none`, `aborted`, or `preserved`)
+  - `cleanup.worktreeRemoved`
+  - `cleanup.branchDeleted`
+  - `cleanup.pruned`
+  - `error?`
+- `conflictState: 'preserved'` means the caller requested `preserveConflicts: true` and must resolve the merge locally before cleanup can finish.
 
 ### Context (1 tool)
 | Tool | Purpose |

--- a/packages/opencode-hive/schema/agent_hive.schema.json
+++ b/packages/opencode-hive/schema/agent_hive.schema.json
@@ -96,6 +96,10 @@
           "$ref": "#/$defs/agentConfig",
           "description": "Forager Worker"
         },
+        "hive-helper": {
+          "$ref": "#/$defs/agentConfig",
+          "description": "Hive Helper"
+        },
         "hygienic-reviewer": {
           "$ref": "#/$defs/agentConfig",
           "description": "Hygienic Reviewer"
@@ -113,6 +117,7 @@
             "swarm-orchestrator",
             "scout-researcher",
             "forager-worker",
+            "hive-helper",
             "hygienic-reviewer",
             "hive",
             "architect",

--- a/packages/opencode-hive/src/__tests__/agent-config-schema.test.ts
+++ b/packages/opencode-hive/src/__tests__/agent-config-schema.test.ts
@@ -34,6 +34,7 @@ describe('agent_hive schema customAgents contract', () => {
     expectReservedNameToFail('swarm-orchestrator');
     expectReservedNameToFail('scout-researcher');
     expectReservedNameToFail('forager-worker');
+    expectReservedNameToFail('hive-helper');
     expectReservedNameToFail('hygienic-reviewer');
     expectReservedNameToFail('hive');
     expectReservedNameToFail('architect');

--- a/packages/opencode-hive/src/__tests__/compaction-hook.test.ts
+++ b/packages/opencode-hive/src/__tests__/compaction-hook.test.ts
@@ -284,6 +284,31 @@ describe('experimental.session.compacting hook — session-aware re-anchoring', 
     expect(cleared?.replayDirectivePending).toBe(false);
   });
 
+  test('hive-helper directive replay keeps helper role and never falls back to current role', async () => {
+    const sessionService = new SessionService(testRoot);
+    sessionService.trackGlobal('sess-helper-replay', {
+      agent: 'hive-helper',
+      sessionKind: 'subagent',
+      directivePrompt: 'Merge the completed branches, resolve preserved conflicts locally, and return only a concise summary.',
+      replayDirectivePending: false,
+    } as any);
+
+    await hooks.event?.({
+      event: {
+        type: 'session.compacted',
+        properties: { sessionID: 'sess-helper-replay' },
+      } as any,
+    });
+
+    const output = buildCompactionTransformOutput('sess-helper-replay', testRoot);
+    await hooks['experimental.chat.messages.transform']?.({}, output as any);
+
+    expect(output.messages).toHaveLength(3);
+    const replayText = (output.messages[2].parts[0] as any).text;
+    expect(replayText).toContain('You are still Hive Helper.');
+    expect(replayText).not.toContain('You are still current role.');
+  });
+
   test('primary/subagent compaction recovery transitions available -> consumed -> escalated', async () => {
     const sessionService = new SessionService(testRoot);
     sessionService.trackGlobal('sess-state-machine', {

--- a/packages/opencode-hive/src/agents/hive-helper.ts
+++ b/packages/opencode-hive/src/agents/hive-helper.ts
@@ -1,0 +1,36 @@
+export const HIVE_HELPER_PROMPT = `# Hive Helper
+
+You are a runtime-only merge recovery subagent. You never plan or orchestrate.
+
+## Core Rules
+
+- never plans or orchestrates
+- use \`hive_merge\` first
+- if merge returns \`conflictState: 'preserved'\`, resolves locally in this helper session and continues the merge batch
+- return only concise merged/conflict/blocker summary text
+
+## Scope
+
+- Merge completed task branches for the caller
+- Handle preserved merge conflicts in this isolated helper session
+- Continue the requested merge batch until complete or blocked
+- Do not start worktrees, rewrite plans, or broaden the assignment
+
+## Execution
+
+1. Call \`hive_merge\` first for the requested task branch.
+2. If the merge succeeds, continue to the next requested merge.
+3. If \`conflictState: 'preserved'\`, inspect and resolves locally, complete the merge, and continue the merge batch.
+4. If you cannot safely resolve a conflict, stop and return a concise blocker summary.
+
+## Output
+
+Return only concise merged/conflict/blocker summary text.
+Do not include planning, orchestration commentary, or long narratives.
+`;
+
+export const hiveHelperAgent = {
+  name: 'Hive Helper',
+  description: 'Runtime-only merge recovery helper. Merges branches and resolves preserved conflicts in isolation.',
+  prompt: HIVE_HELPER_PROMPT,
+};

--- a/packages/opencode-hive/src/agents/hive.ts
+++ b/packages/opencode-hive/src/agents/hive.ts
@@ -209,9 +209,10 @@ hive_worktree_start({ task: "01-task-name" })  // Creates worktree + Forager
 When multiple tasks are in flight, prefer **batch completion** over per-task verification:
 1. Dispatch a batch of runnable tasks (ask user before parallelizing).
 2. Wait for all workers to finish.
-3. Merge each completed task branch into the current branch.
-4. Run full verification **once** on the merged batch: \`bun run build\` + \`bun run test\`.
-5. If verification fails, diagnose with full context. Fix directly or re-dispatch targeted tasks as needed.
+3. Decide which completed task branches belong in the next merge batch.
+4. Delegate the merge batch to \`hive-helper\`, for example: \`task({ subagent_type: 'hive-helper', prompt: 'delegate the merge batch: merge completed tasks 01-task-name and 02-task-name into the current branch, resolve preserved conflicts locally, continue through the batch, and return a concise summary.' })\`.
+5. After the helper returns, inspect the merge summary and run full verification **once** on the merged batch: \`bun run build\` + \`bun run test\`.
+6. If verification fails, diagnose with full context. Fix directly or re-dispatch targeted tasks as needed.
 
 ### Failure Recovery (After 3 Consecutive Failures)
 1. Stop all further edits
@@ -220,7 +221,7 @@ When multiple tasks are in flight, prefer **batch completion** over per-task ver
 4. Ask user via question() — present options and context
 
 ### Merge Strategy
-\`hive_merge({ task: "01-task-name" })\` for each task after the batch completes, then verify the batch
+Hive decides when to merge, delegated \`hive-helper\` executes the batch, and Hive keeps post-batch verification.
 
 ### Post-Batch Review (Hygienic)
 After completing and merging a batch:

--- a/packages/opencode-hive/src/agents/index.ts
+++ b/packages/opencode-hive/src/agents/index.ts
@@ -16,6 +16,7 @@ export { architectBeeAgent, ARCHITECT_BEE_PROMPT } from './architect';
 export { swarmBeeAgent, SWARM_BEE_PROMPT } from './swarm';
 export { scoutBeeAgent, SCOUT_BEE_PROMPT } from './scout';
 export { foragerBeeAgent, FORAGER_BEE_PROMPT } from './forager';
+export { hiveHelperAgent, HIVE_HELPER_PROMPT } from './hive-helper';
 export { hygienicBeeAgent, HYGIENIC_BEE_PROMPT } from './hygienic';
 
 
@@ -55,6 +56,11 @@ export const hiveAgents = {
   forager: {
     name: 'Forager (Worker/Coder)',
     description: 'Executes tasks directly in isolated worktrees. Never delegates.',
+    mode: 'subagent' as const,
+  },
+  'hive-helper': {
+    name: 'Hive Helper',
+    description: 'Runtime-only merge recovery helper. Merges branches and resolves preserved conflicts in isolation.',
     mode: 'subagent' as const,
   },
   hygienic: {

--- a/packages/opencode-hive/src/agents/permissions.test.ts
+++ b/packages/opencode-hive/src/agents/permissions.test.ts
@@ -102,6 +102,7 @@ describe('Agent permissions', () => {
     expect(opencodeConfig.agent?.['architect-planner']).toBeUndefined();
     expect(opencodeConfig.agent?.['scout-researcher']).toBeTruthy();
     expect(opencodeConfig.agent?.['forager-worker']).toBeTruthy();
+    expect(opencodeConfig.agent?.['hive-helper']).toBeTruthy();
     expect(opencodeConfig.agent?.['hygienic-reviewer']).toBeTruthy();
     expect(opencodeConfig.default_agent).toBe('hive-master');
 
@@ -143,6 +144,7 @@ describe('Agent permissions', () => {
     expect(opencodeConfig.agent?.['architect-planner']).toBeTruthy();
     expect(opencodeConfig.agent?.['scout-researcher']).toBeTruthy();
     expect(opencodeConfig.agent?.['forager-worker']).toBeTruthy();
+    expect(opencodeConfig.agent?.['hive-helper']).toBeTruthy();
     expect(opencodeConfig.agent?.['hygienic-reviewer']).toBeTruthy();
     expect(opencodeConfig.default_agent).toBe('architect-planner');
 
@@ -182,13 +184,56 @@ describe('Agent permissions', () => {
     } = {};
     await hooks.config?.(opencodeConfig);
 
-    const subagentNames = ['scout-researcher', 'forager-worker', 'hygienic-reviewer'] as const;
+    const subagentNames = ['scout-researcher', 'forager-worker', 'hive-helper', 'hygienic-reviewer'] as const;
     for (const name of subagentNames) {
       const perm = opencodeConfig.agent?.[name]?.permission;
       expect(perm).toBeTruthy();
       expect(perm!.task).toBe('deny');
       expect(perm!.delegate).toBe('deny');
     }
+  });
+
+  it('gives hive-helper only merge recovery tools and no auto-loaded skills appendix', async () => {
+    spyOn(ConfigService.prototype, 'get').mockReturnValue({
+      agentMode: 'unified',
+      agents: {
+        'hive-master': {},
+        'hive-helper': {},
+      },
+    } as any);
+
+    const repoRoot = path.resolve(import.meta.dir, '..', '..', '..', '..');
+    const ctx: PluginInput = {
+      directory: repoRoot,
+      worktree: repoRoot,
+      serverUrl: new URL('http://localhost:1'),
+      project: { id: 'test', worktree: repoRoot, time: { created: Date.now() } },
+      client: createStubClient(),
+      $: createStubShell(),
+    };
+
+    const hooks = await plugin(ctx as any);
+    const opencodeConfig: {
+      agent?: Record<string, AgentConfig>;
+      default_agent?: string;
+    } = {};
+    await hooks.config?.(opencodeConfig);
+
+    const helper = opencodeConfig.agent?.['hive-helper'];
+    expect(helper).toBeTruthy();
+    expect(helper?.tools).toBeTruthy();
+    expect(helper?.tools?.['hive_merge']).toBeUndefined();
+    expect(helper?.tools?.['hive_status']).toBeUndefined();
+    expect(helper?.tools?.['hive_context_write']).toBeUndefined();
+    expect(helper?.tools?.['hive_skill']).toBeUndefined();
+    expect(helper?.tools?.['hive_worktree_start']).toBe(false);
+    expect(helper?.tools?.['hive_worktree_create']).toBe(false);
+    expect(helper?.tools?.['hive_worktree_commit']).toBe(false);
+    expect(helper?.tools?.['hive_plan_write']).toBe(false);
+    expect(helper?.permission?.task).toBe('deny');
+    expect(helper?.permission?.delegate).toBe('deny');
+    expect(helper?.permission?.skill).toBe('allow');
+    expect(helper?.prompt).not.toContain('## Hive Skill:');
   });
 
   it('inherits subagent safety restrictions for custom forager and hygienic families', async () => {
@@ -287,6 +332,21 @@ describe('Per-agent tool filtering', () => {
     expect(foragerTools!['hive_worktree_commit']).toBeUndefined();
     expect(foragerTools!['hive_context_write']).toBeUndefined();
     expect(foragerTools!['hive_skill']).toBeUndefined();
+  });
+
+  it('hive-helper tool list is exactly [hive_merge, hive_status, hive_context_write, hive_skill]', async () => {
+    const agents = await buildConfig('unified');
+    const helperTools = agents['hive-helper']?.tools;
+    expect(helperTools).toBeTruthy();
+    expect(helperTools!['hive_merge']).toBeUndefined();
+    expect(helperTools!['hive_status']).toBeUndefined();
+    expect(helperTools!['hive_context_write']).toBeUndefined();
+    expect(helperTools!['hive_skill']).toBeUndefined();
+    expect(helperTools!['hive_plan_read']).toBe(false);
+    expect(helperTools!['hive_worktree_commit']).toBe(false);
+    expect(helperTools!['hive_worktree_start']).toBe(false);
+    expect(helperTools!['hive_worktree_create']).toBe(false);
+    expect(helperTools!['hive_tasks_sync']).toBe(false);
   });
 
   it('scout has only read-only hive tools (no worktree_commit, no merge)', async () => {

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -378,6 +378,10 @@ describe('Hygienic (Consultant/Reviewer) prompt', () => {
 describe('README.md documentation', () => {
   const README_PATH = path.resolve(import.meta.dir, '..', '..', 'README.md');
   const readmeContent = readFileSync(README_PATH, 'utf-8');
+  const ROOT_README_PATH = path.resolve(import.meta.dir, '..', '..', '..', '..', 'README.md');
+  const rootReadmeContent = readFileSync(ROOT_README_PATH, 'utf-8');
+  const HIVE_TOOLS_PATH = path.resolve(import.meta.dir, '..', '..', 'docs', 'HIVE-TOOLS.md');
+  const hiveToolsContent = readFileSync(HIVE_TOOLS_PATH, 'utf-8');
 
   describe('delegation planning alignment', () => {
     it('contains the heading "### Planning-mode delegation"', () => {
@@ -396,6 +400,42 @@ describe('README.md documentation', () => {
     it('contains the Canonical Delegation Threshold content', () => {
       expect(readmeContent).toContain('cannot name the file path upfront');
       expect(readmeContent).toContain('2+ files');
+    });
+  });
+
+  describe('hive-helper runtime docs alignment', () => {
+    it('documents hive-helper in runtime-facing recovery docs', () => {
+      expect(readmeContent).toContain('`hive-helper`');
+      expect(readmeContent).toContain('runtime-only');
+      expect(readmeContent).toContain('merge recovery');
+    });
+
+    it('documents hive-helper in the built-in agent defaults table', () => {
+      expect(readmeContent).toContain('| `hive-helper` | (none) |');
+    });
+
+    it('keeps hive-helper out of custom derived subagent docs', () => {
+      expect(readmeContent).toContain('does not appear in `.github/agents/`');
+      expect(readmeContent).toContain('does not appear in `packages/vscode-hive/src/generators/`');
+      expect(readmeContent).toContain('### Custom Derived Subagents');
+      expect(readmeContent).not.toContain('`baseAgent`: one of `forager-worker`, `hygienic-reviewer`, or `hive-helper`');
+    });
+
+    it('documents hive-helper in the top-level runtime roster and recovery notes', () => {
+      expect(rootReadmeContent).toContain('**Hive Helper**');
+      expect(rootReadmeContent).toContain('Runtime-only merge recovery helper');
+      expect(rootReadmeContent).toContain('does not appear in generated `.github/agents/` docs');
+      expect(rootReadmeContent).toContain('does not appear in `packages/vscode-hive/src/generators/`');
+    });
+
+    it('documents the expanded hive_merge contract', () => {
+      expect(hiveToolsContent).toContain('preserveConflicts');
+      expect(hiveToolsContent).toContain('cleanup');
+      expect(hiveToolsContent).toContain('conflictState');
+      expect(hiveToolsContent).toContain('worktreeRemoved');
+      expect(hiveToolsContent).toContain('branchDeleted');
+      expect(hiveToolsContent).toContain('pruned');
+      expect(hiveToolsContent).toContain('message');
     });
   });
 });

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -6,6 +6,7 @@ import { ARCHITECT_BEE_PROMPT } from './architect';
 import { SWARM_BEE_PROMPT } from './swarm';
 import { FORAGER_BEE_PROMPT } from './forager';
 import { SCOUT_BEE_PROMPT } from './scout';
+import { HIVE_HELPER_PROMPT } from './hive-helper';
 import { HYGIENIC_BEE_PROMPT } from './hygienic';
 
 describe('Hive (Hybrid) prompt', () => {
@@ -303,6 +304,24 @@ describe('Forager (Worker/Coder) prompt', () => {
 
   it('contains docker-mastery skill reference', () => {
     expect(FORAGER_BEE_PROMPT).toContain('docker-mastery');
+  });
+});
+
+describe('Hive Helper prompt', () => {
+  it('forbids planning and orchestration', () => {
+    expect(HIVE_HELPER_PROMPT).toContain('never plans or orchestrates');
+  });
+
+  it('uses hive_merge first and resolves preserved conflicts locally', () => {
+    expect(HIVE_HELPER_PROMPT).toContain('hive_merge');
+    expect(HIVE_HELPER_PROMPT).toContain("conflictState: 'preserved'");
+    expect(HIVE_HELPER_PROMPT).toContain('resolves locally');
+    expect(HIVE_HELPER_PROMPT).toContain('continues the merge batch');
+  });
+
+  it('requires concise summary-only output', () => {
+    expect(HIVE_HELPER_PROMPT).toContain('concise');
+    expect(HIVE_HELPER_PROMPT).toContain('merged/conflict/blocker summary');
   });
 });
 

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -70,6 +70,14 @@ describe('Hive (Hybrid) prompt', () => {
     it('tells hybrid planners to split broad research earlier', () => {
       expect(QUEEN_BEE_PROMPT).toContain('split broad research earlier');
     });
+
+    it('delegates batch merges to hive-helper and keeps post-batch verification with Hive', () => {
+      expect(QUEEN_BEE_PROMPT).toContain("task({ subagent_type: 'hive-helper'");
+      expect(QUEEN_BEE_PROMPT).toContain('delegate the merge batch');
+      expect(QUEEN_BEE_PROMPT).toContain('After the helper returns');
+      expect(QUEEN_BEE_PROMPT).toContain('bun run build');
+      expect(QUEEN_BEE_PROMPT).toContain('bun run test');
+    });
   });
 
   describe('turn termination and hard blocks', () => {
@@ -230,6 +238,14 @@ describe('Swarm (Orchestrator) prompt', () => {
 
     it('tells orchestrators to split broad research earlier', () => {
       expect(SWARM_BEE_PROMPT).toContain('split broad research earlier');
+    });
+
+    it('delegates batch merges to hive-helper and keeps post-batch verification with Swarm', () => {
+      expect(SWARM_BEE_PROMPT).toContain("task({ subagent_type: 'hive-helper'");
+      expect(SWARM_BEE_PROMPT).toContain('delegate the merge batch');
+      expect(SWARM_BEE_PROMPT).toContain('After the helper returns');
+      expect(SWARM_BEE_PROMPT).toContain('bun run build');
+      expect(SWARM_BEE_PROMPT).toContain('bun run test');
     });
   });
 

--- a/packages/opencode-hive/src/agents/swarm.ts
+++ b/packages/opencode-hive/src/agents/swarm.ts
@@ -100,11 +100,13 @@ When worker reports blocked: \`hive_status()\` → confirm status is exactly \`b
 
 ## Merge Strategy
 
+Swarm decides when to merge, then delegate the merge batch to \`hive-helper\`, for example:
+
 \`\`\`
-hive_merge({ task: "01-task-name", strategy: "merge" })
+task({ subagent_type: 'hive-helper', prompt: 'delegate the merge batch: merge completed tasks 01-task-name and 02-task-name into the current branch, resolve preserved conflicts locally, continue through the batch, and return a concise summary.' })
 \`\`\`
 
-Merge after batch completes, then verify the merged result.
+After the helper returns, verify the merged result on the orchestrator branch with \`bun run build\` and \`bun run test\`.
 
 ### Post-Batch Review (Hygienic)
 

--- a/packages/opencode-hive/src/e2e/agent-mode.test.ts
+++ b/packages/opencode-hive/src/e2e/agent-mode.test.ts
@@ -64,6 +64,7 @@ describe("agentMode gating", () => {
     expect(opencodeConfig.agent["swarm-orchestrator"]).toBeUndefined();
     expect(opencodeConfig.agent["scout-researcher"]).toBeDefined();
     expect(opencodeConfig.agent["forager-worker"]).toBeDefined();
+    expect(opencodeConfig.agent["hive-helper"]).toBeDefined();
     expect(opencodeConfig.agent["hygienic-reviewer"]).toBeDefined();
     expect(opencodeConfig.default_agent).toBe("hive-master");
   });
@@ -95,6 +96,7 @@ describe("agentMode gating", () => {
     expect(opencodeConfig.agent["swarm-orchestrator"]).toBeDefined();
     expect(opencodeConfig.agent["scout-researcher"]).toBeDefined();
     expect(opencodeConfig.agent["forager-worker"]).toBeDefined();
+    expect(opencodeConfig.agent["hive-helper"]).toBeDefined();
     expect(opencodeConfig.agent["hygienic-reviewer"]).toBeDefined();
     expect(opencodeConfig.default_agent).toBe("architect-planner");
   });

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -2035,6 +2035,54 @@ Do it
     });
   });
 
+  it("returns helper-friendly merge JSON when task is not completed", async () => {
+    const feature = "merge-incomplete-task-feature";
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      "sess_merge_incomplete_task",
+      feature,
+      "Merge Incomplete Task Feature",
+      "Yes, this test validates the early hive_merge JSON contract for incomplete tasks.",
+    );
+
+    const mergeRaw = await hooks.tool!.hive_merge.execute(
+      {
+        feature,
+        task: FIRST_TASK,
+        strategy: "merge",
+      },
+      toolContext
+    );
+
+    const mergeResult = JSON.parse(mergeRaw as string) as {
+      success: boolean;
+      merged: boolean;
+      strategy: string;
+      filesChanged: string[];
+      conflicts: string[];
+      conflictState: string;
+      cleanup: { worktreeRemoved: boolean; branchDeleted: boolean; pruned: boolean };
+      error?: string;
+      message: string;
+    };
+
+    expect(mergeResult).toEqual({
+      success: false,
+      merged: false,
+      strategy: 'merge',
+      filesChanged: [],
+      conflicts: [],
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruned: false,
+      },
+      error: 'Task must be completed before merging. Use hive_worktree_commit first.',
+      message: 'Merge failed: Task must be completed before merging. Use hive_worktree_commit first.',
+    });
+  });
+
   it("auto-loads parallel exploration for planner agents by default", async () => {
     // Test unified mode agents
     const ctx: PluginInput = {

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -1897,7 +1897,7 @@ Do it
     expect(readHeadBody(worktreePath)).toBe(expectedMessage);
   });
 
-  it("passes custom merge message through for merge strategy", async () => {
+  it("returns helper-friendly merge JSON for merge strategy", async () => {
     const feature = "merge-custom-message-feature";
     const { hooks, toolContext, worktreePath } = await createSingleTaskWorktree(
       testRoot,
@@ -1937,7 +1937,33 @@ Do it
       toolContext
     );
 
-    expect(mergeRaw).toContain("merged successfully using merge strategy");
+    const mergeResult = JSON.parse(mergeRaw as string) as {
+      success: boolean;
+      merged: boolean;
+      strategy: string;
+      sha?: string;
+      filesChanged: string[];
+      conflicts: string[];
+      conflictState: string;
+      cleanup: { worktreeRemoved: boolean; branchDeleted: boolean; pruned: boolean };
+      message: string;
+    };
+
+    expect(mergeResult).toMatchObject({
+      success: true,
+      merged: true,
+      strategy: 'merge',
+      filesChanged: ['task-note.txt'],
+      conflicts: [],
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruned: false,
+      },
+      message: 'Task "01-first-task" merged successfully using merge strategy.',
+    });
+    expect(typeof mergeResult.sha).toBe('string');
     expect(readHeadBody(testRoot)).toBe(customMessage);
   });
 
@@ -1980,8 +2006,33 @@ Do it
       toolContext
     );
 
-    expect(mergeRaw).toContain("Merge failed:");
-    expect(mergeRaw).toContain("Custom merge message is not supported for rebase strategy");
+    const mergeResult = JSON.parse(mergeRaw as string) as {
+      success: boolean;
+      merged: boolean;
+      strategy: string;
+      filesChanged: string[];
+      conflicts: string[];
+      conflictState: string;
+      cleanup: { worktreeRemoved: boolean; branchDeleted: boolean; pruned: boolean };
+      error?: string;
+      message: string;
+    };
+
+    expect(mergeResult).toEqual({
+      success: false,
+      merged: false,
+      strategy: 'rebase',
+      filesChanged: [],
+      conflicts: [],
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: false,
+        branchDeleted: false,
+        pruned: false,
+      },
+      error: 'Custom merge message is not supported for rebase strategy',
+      message: 'Merge failed: Custom merge message is not supported for rebase strategy',
+    });
   });
 
   it("auto-loads parallel exploration for planner agents by default", async () => {

--- a/packages/opencode-hive/src/hooks/variant-hook.test.ts
+++ b/packages/opencode-hive/src/hooks/variant-hook.test.ts
@@ -64,6 +64,7 @@ describe('createVariantHook', () => {
         'swarm-orchestrator': 'medium',
         'scout-researcher': 'low',
         'forager-worker': 'high',
+        'hive-helper': 'medium',
         'hygienic-reviewer': 'medium',
       };
 
@@ -271,6 +272,12 @@ describe('classifySession', () => {
       const result = classifySession('hygienic-reviewer', NO_CUSTOM_AGENTS);
       expect(result.sessionKind).toBe('subagent');
       expect(result.baseAgent).toBe('hygienic-reviewer');
+    });
+
+    it('classifies hive-helper as subagent', () => {
+      const result = classifySession('hive-helper', NO_CUSTOM_AGENTS);
+      expect(result.sessionKind).toBe('subagent');
+      expect(result.baseAgent).toBe('hive-helper');
     });
   });
 

--- a/packages/opencode-hive/src/hooks/variant-hook.ts
+++ b/packages/opencode-hive/src/hooks/variant-hook.ts
@@ -12,6 +12,7 @@ const BUILT_IN_AGENTS: Record<string, { sessionKind: SessionKind; baseAgent: str
   'swarm-orchestrator': { sessionKind: 'primary', baseAgent: 'swarm-orchestrator' },
   'forager-worker': { sessionKind: 'task-worker', baseAgent: 'forager-worker' },
   'scout-researcher': { sessionKind: 'subagent', baseAgent: 'scout-researcher' },
+  'hive-helper': { sessionKind: 'subagent', baseAgent: 'hive-helper' },
   'hygienic-reviewer': { sessionKind: 'subagent', baseAgent: 'hygienic-reviewer' },
 };
 

--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -1648,12 +1648,28 @@ Expand your Discovery section and try again.`;
           feature: tool.schema.string().optional().describe('Feature name (defaults to active)'),
         },
         async execute({ task, strategy = 'merge', message, preserveConflicts, cleanup, feature: explicitFeature }) {
+          const failure = (error: string) => respond({
+            success: false,
+            merged: false,
+            strategy,
+            filesChanged: [],
+            conflicts: [],
+            conflictState: 'none',
+            cleanup: {
+              worktreeRemoved: false,
+              branchDeleted: false,
+              pruned: false,
+            },
+            error,
+            message: `Merge failed: ${error}`,
+          });
+
           const feature = resolveFeature(explicitFeature);
-          if (!feature) return "Error: No feature specified. Create a feature or provide feature param.";
+          if (!feature) return failure('No feature specified. Create a feature or provide feature param.');
 
           const taskInfo = taskService.get(feature, task);
-          if (!taskInfo) return `Error: Task "${task}" not found`;
-          if (taskInfo.status !== 'done') return "Error: Task must be completed before merging. Use hive_worktree_commit first.";
+          if (!taskInfo) return failure(`Task "${task}" not found`);
+          if (taskInfo.status !== 'done') return failure('Task must be completed before merging. Use hive_worktree_commit first.');
 
           const result = await worktreeService.merge(feature, task, strategy, message, {
             preserveConflicts,

--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -1640,9 +1640,11 @@ Expand your Discovery section and try again.`;
           task: tool.schema.string().describe('Task folder name to merge'),
           strategy: tool.schema.enum(['merge', 'squash', 'rebase']).optional().describe('Merge strategy (default: merge)'),
           message: tool.schema.string().optional().describe('Optional merge message for merge/squash. Empty uses default.'),
+          preserveConflicts: tool.schema.boolean().optional().describe('Keep merge conflict state intact instead of auto-aborting (default: false).'),
+          cleanup: tool.schema.enum(['none', 'worktree', 'worktree+branch']).optional().describe('Cleanup mode after a successful merge (default: none).'),
           feature: tool.schema.string().optional().describe('Feature name (defaults to active)'),
         },
-        async execute({ task, strategy = 'merge', message, feature: explicitFeature }) {
+        async execute({ task, strategy = 'merge', message, preserveConflicts, cleanup, feature: explicitFeature }) {
           const feature = resolveFeature(explicitFeature);
           if (!feature) return "Error: No feature specified. Create a feature or provide feature param.";
 
@@ -1650,16 +1652,19 @@ Expand your Discovery section and try again.`;
           if (!taskInfo) return `Error: Task "${task}" not found`;
           if (taskInfo.status !== 'done') return "Error: Task must be completed before merging. Use hive_worktree_commit first.";
 
-          const result = await worktreeService.merge(feature, task, strategy, message);
+          const result = await worktreeService.merge(feature, task, strategy, message, {
+            preserveConflicts,
+            cleanup,
+          });
 
-          if (!result.success) {
-            if (result.conflicts && result.conflicts.length > 0) {
-              return `Merge failed with conflicts in:\n${result.conflicts.map(f => `- ${f}`).join('\n')}\n\nResolve conflicts manually or try a different strategy.`;
-            }
-            return `Merge failed: ${result.error}`;
-          }
+          const responseMessage = result.success
+            ? `Task "${task}" merged successfully using ${strategy} strategy.`
+            : `Merge failed: ${result.error}`;
 
-          return `Task "${task}" merged successfully using ${strategy} strategy.\nCommit: ${result.sha}\nFiles changed: ${result.filesChanged?.length || 0}`;
+          return respond({
+            ...result,
+            message: responseMessage,
+          });
         },
       }),
 

--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -12,6 +12,7 @@ import { ARCHITECT_BEE_PROMPT } from './agents/architect.js';
 import { SWARM_BEE_PROMPT } from './agents/swarm.js';
 import { SCOUT_BEE_PROMPT } from './agents/scout.js';
 import { FORAGER_BEE_PROMPT } from './agents/forager.js';
+import { HIVE_HELPER_PROMPT } from './agents/hive-helper.js';
 import { HYGIENIC_BEE_PROMPT } from './agents/hygienic.js';
 import { buildCustomSubagents } from './agents/custom-agents.js';
 import { createBuiltinMcps } from './mcp/index.js';
@@ -335,6 +336,8 @@ const plugin: Plugin = async (ctx) => {
     if (!session.directivePrompt) return null;
     const role = session.agent === 'scout-researcher' || session.baseAgent === 'scout-researcher'
       ? 'Scout'
+      : session.agent === 'hive-helper' || session.baseAgent === 'hive-helper'
+        ? 'Hive Helper'
       : session.agent === 'hygienic-reviewer' || session.baseAgent === 'hygienic-reviewer'
         ? 'Hygienic'
         : session.agent === 'architect-planner' || session.baseAgent === 'architect-planner'
@@ -2056,6 +2059,22 @@ Expand your Discovery section and try again.`;
         },
       };
 
+      const hiveHelperUserConfig = configService.getAgentConfig('hive-helper');
+      const hiveHelperConfig = {
+        model: hiveHelperUserConfig.model,
+        variant: hiveHelperUserConfig.variant,
+        temperature: hiveHelperUserConfig.temperature ?? 0.3,
+        mode: 'subagent' as const,
+        description: 'Hive Helper - Runtime-only merge recovery helper. Merges branches and resolves preserved conflicts in isolation.',
+        prompt: HIVE_HELPER_PROMPT,
+        tools: agentTools(['hive_merge', 'hive_status', 'hive_context_write', 'hive_skill']),
+        permission: {
+          task: 'deny',
+          delegate: 'deny',
+          skill: 'allow',
+        },
+      };
+
       const hygienicUserConfig = configService.getAgentConfig('hygienic-reviewer');
       const hygienicAutoLoadedSkills = await buildAutoLoadedSkillsContent('hygienic-reviewer', configService, directory);
       const hygienicConfig = {
@@ -2080,6 +2099,7 @@ Expand your Discovery section and try again.`;
         'swarm-orchestrator': swarmConfig,
         'scout-researcher': scoutConfig,
         'forager-worker': foragerConfig,
+        'hive-helper': hiveHelperConfig,
         'hygienic-reviewer': hygienicConfig,
       };
 
@@ -2117,12 +2137,14 @@ Expand your Discovery section and try again.`;
         allAgents['hive-master'] = builtInAgentConfigs['hive-master'];
         allAgents['scout-researcher'] = builtInAgentConfigs['scout-researcher'];
         allAgents['forager-worker'] = builtInAgentConfigs['forager-worker'];
+        allAgents['hive-helper'] = builtInAgentConfigs['hive-helper'];
         allAgents['hygienic-reviewer'] = builtInAgentConfigs['hygienic-reviewer'];
       } else {
         allAgents['architect-planner'] = builtInAgentConfigs['architect-planner'];
         allAgents['swarm-orchestrator'] = builtInAgentConfigs['swarm-orchestrator'];
         allAgents['scout-researcher'] = builtInAgentConfigs['scout-researcher'];
         allAgents['forager-worker'] = builtInAgentConfigs['forager-worker'];
+        allAgents['hive-helper'] = builtInAgentConfigs['hive-helper'];
         allAgents['hygienic-reviewer'] = builtInAgentConfigs['hygienic-reviewer'];
       }
 
@@ -2147,6 +2169,7 @@ Expand your Discovery section and try again.`;
         delete (configAgent as Record<string, unknown>)['swarm-orchestrator'];
         delete (configAgent as Record<string, unknown>)['scout-researcher'];
         delete (configAgent as Record<string, unknown>)['forager-worker'];
+        delete (configAgent as Record<string, unknown>)['hive-helper'];
         delete (configAgent as Record<string, unknown>)['hygienic-reviewer'];
         Object.assign(configAgent, allAgents);
       }

--- a/packages/opencode-hive/src/utils/compaction-anchor.test.ts
+++ b/packages/opencode-hive/src/utils/compaction-anchor.test.ts
@@ -114,6 +114,14 @@ describe('buildCompactionReanchor', () => {
       expect(anchor.prompt).toContain('Role: Hygienic');
     });
 
+    it('anchors hive-helper with Role: Hive Helper', () => {
+      const anchor = buildCompactionReanchor({
+        agent: 'hive-helper',
+        sessionKind: 'subagent',
+      });
+      expect(anchor.prompt).toContain('Role: Hive Helper');
+    });
+
     it('anchors custom hygienic-reviewer derivative with Role: Hygienic', () => {
       const anchor = buildCompactionReanchor({
         agent: 'my-custom-reviewer',

--- a/packages/opencode-hive/src/utils/compaction-anchor.ts
+++ b/packages/opencode-hive/src/utils/compaction-anchor.ts
@@ -19,6 +19,7 @@ const AGENT_ROLE_MAP: Record<string, string> = {
   'swarm-orchestrator': 'Swarm',
   'forager-worker': 'Forager',
   'scout-researcher': 'Scout',
+  'hive-helper': 'Hive Helper',
   'hygienic-reviewer': 'Hygienic',
 };
 
@@ -26,6 +27,7 @@ const BASE_AGENT_ROLE_MAP: Record<string, string> = {
   'forager-worker': 'Forager',
   'hygienic-reviewer': 'Hygienic',
   'scout-researcher': 'Scout',
+  'hive-helper': 'Hive Helper',
 };
 
 function resolveRole(ctx: CompactionSessionContext): string | undefined {

--- a/packages/opencode-hive/src/utils/worker-prompt.test.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.test.ts
@@ -165,6 +165,14 @@ UNIQUE_MARKER_12345
     expect(prompt).toContain('result.nextAction');
   });
 
+  it('keeps ordinary workers merge-forbidden and delegation-forbidden', () => {
+    const params = createTestParams();
+    const prompt = buildWorkerPrompt(params);
+
+    expect(prompt).toContain('`hive_merge` - Only Hive/Swarm or delegated `hive-helper` merges');
+    expect(prompt).toContain('`task` - No recursive delegation; only Hive/Swarm may delegate `hive-helper`');
+  });
+
   it('includes worktree restriction warning', () => {
     const params = createTestParams();
     const prompt = buildWorkerPrompt(params);

--- a/packages/opencode-hive/src/utils/worker-prompt.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.ts
@@ -236,8 +236,8 @@ After 3 failed attempts at same fix: STOP and report blocker.
 **You do NOT have access to (or should not use):**
 - \`question\` - Escalate via blocker protocol instead
 - \`hive_worktree_create\` - No spawning sub-workers
-- \`hive_merge\` - Only Hive Master merges
-- \`task\` - No recursive delegation
+- \`hive_merge\` - Only Hive/Swarm or delegated \`hive-helper\` merges; ordinary task workers must not merge
+- \`task\` - No recursive delegation; only Hive/Swarm may delegate \`hive-helper\`
 
 ---
 

--- a/packages/vscode-hive/dist/extension.js
+++ b/packages/vscode-hive/dist/extension.js
@@ -1607,6 +1607,7 @@ var BUILT_IN_AGENT_NAMES = [
   "swarm-orchestrator",
   "scout-researcher",
   "forager-worker",
+  "hive-helper",
   "hygienic-reviewer"
 ];
 var CUSTOM_AGENT_RESERVED_NAMES = [
@@ -1628,6 +1629,7 @@ var DEFAULT_AGENT_MODELS = {
   "swarm-orchestrator": "github-copilot/claude-opus-4.5",
   "scout-researcher": "zai-coding-plan/glm-4.7",
   "forager-worker": "github-copilot/gpt-5.2-codex",
+  "hive-helper": "github-copilot/gpt-5.2-codex",
   "hygienic-reviewer": "github-copilot/gpt-5.2-codex"
 };
 var DEFAULT_HIVE_CONFIG = {
@@ -1686,6 +1688,11 @@ var DEFAULT_HIVE_CONFIG = {
       model: DEFAULT_AGENT_MODELS["forager-worker"],
       temperature: 0.3,
       autoLoadSkills: ["test-driven-development", "verification-before-completion"]
+    },
+    "hive-helper": {
+      model: DEFAULT_AGENT_MODELS["hive-helper"],
+      temperature: 0.3,
+      autoLoadSkills: []
     },
     "hygienic-reviewer": {
       model: DEFAULT_AGENT_MODELS["hygienic-reviewer"],
@@ -7130,21 +7137,29 @@ var WorktreeService = class {
     const worktreePath = this.getWorktreePath(feature, step);
     const branchName = this.getBranchName(feature, step);
     const git = this.getGit();
+    let worktreeRemoved = false;
+    let branchDeleted = false;
+    let pruned = false;
     try {
       await git.raw(["worktree", "remove", worktreePath, "--force"]);
+      worktreeRemoved = true;
     } catch {
       await fs7.rm(worktreePath, { recursive: true, force: true });
+      worktreeRemoved = true;
     }
     try {
       await git.raw(["worktree", "prune"]);
+      pruned = true;
     } catch {
     }
     if (deleteBranch) {
       try {
         await git.deleteLocalBranch(branchName, true);
+        branchDeleted = true;
       } catch {
       }
     }
+    return { worktreeRemoved, branchDeleted, pruned };
   }
   async list(feature) {
     const worktreesDir = this.getWorktreesDir();
@@ -7280,34 +7295,61 @@ var WorktreeService = class {
       };
     }
   }
-  async merge(feature, step, strategy = "merge", message) {
+  async merge(feature, step, strategy = "merge", message, options = {}) {
     const branchName = this.getBranchName(feature, step);
     const git = this.getGit();
+    const cleanupMode = options.cleanup ?? "none";
+    const preserveConflicts = options.preserveConflicts ?? false;
+    const emptyCleanup = {
+      worktreeRemoved: false,
+      branchDeleted: false,
+      pruned: false
+    };
     if (strategy === "rebase" && message) {
       return {
         success: false,
         merged: false,
+        strategy,
+        filesChanged: [],
+        conflicts: [],
+        conflictState: "none",
+        cleanup: emptyCleanup,
         error: "Custom merge message is not supported for rebase strategy"
       };
     }
+    let filesChanged = [];
     try {
       const branches = await git.branch();
       if (!branches.all.includes(branchName)) {
-        return { success: false, merged: false, error: `Branch ${branchName} not found` };
+        return {
+          success: false,
+          merged: false,
+          strategy,
+          filesChanged: [],
+          conflicts: [],
+          conflictState: "none",
+          cleanup: emptyCleanup,
+          error: `Branch ${branchName} not found`
+        };
       }
       const currentBranch = branches.current;
       const diffStat = await git.diff([`${currentBranch}...${branchName}`, "--stat"]);
-      const filesChanged = diffStat.split(`
+      filesChanged = diffStat.split(`
 `).filter((l) => l.trim() && l.includes("|")).map((l) => l.split("|")[0].trim());
       if (strategy === "squash") {
         await git.raw(["merge", "--squash", branchName]);
         const squashMessage = message || `hive: merge ${step} (squashed)`;
         const result = await git.commit(squashMessage);
+        const cleanup = cleanupMode === "none" ? emptyCleanup : await this.remove(feature, step, cleanupMode === "worktree+branch");
         return {
           success: true,
           merged: true,
+          strategy,
           sha: result.commit,
-          filesChanged
+          filesChanged,
+          conflicts: [],
+          conflictState: "none",
+          cleanup
         };
       } else if (strategy === "rebase") {
         const commits = await git.log([`${currentBranch}..${branchName}`]);
@@ -7316,43 +7358,65 @@ var WorktreeService = class {
           await git.raw(["cherry-pick", commit.hash]);
         }
         const head = (await git.revparse(["HEAD"])).trim();
+        const cleanup = cleanupMode === "none" ? emptyCleanup : await this.remove(feature, step, cleanupMode === "worktree+branch");
         return {
           success: true,
           merged: true,
+          strategy,
           sha: head,
-          filesChanged
+          filesChanged,
+          conflicts: [],
+          conflictState: "none",
+          cleanup
         };
       } else {
         const mergeMessage = message || `hive: merge ${step}`;
         const result = await git.merge([branchName, "--no-ff", "-m", mergeMessage]);
         const head = (await git.revparse(["HEAD"])).trim();
+        const cleanup = cleanupMode === "none" ? emptyCleanup : await this.remove(feature, step, cleanupMode === "worktree+branch");
         return {
           success: true,
           merged: !result.failed,
+          strategy,
           sha: head,
           filesChanged,
-          conflicts: result.conflicts?.map((c) => c.file || String(c)) || []
+          conflicts: result.conflicts?.map((c) => c.file || String(c)) || [],
+          conflictState: "none",
+          cleanup
         };
       }
     } catch (error) {
       const err = error;
       if (err.message?.includes("CONFLICT") || err.message?.includes("conflict")) {
-        await git.raw(["merge", "--abort"]).catch(() => {
-        });
-        await git.raw(["rebase", "--abort"]).catch(() => {
-        });
-        await git.raw(["cherry-pick", "--abort"]).catch(() => {
-        });
+        const conflicts2 = await this.getActiveConflictFiles(git, err.message || "");
+        const conflictState = preserveConflicts ? "preserved" : "aborted";
+        if (!preserveConflicts) {
+          await git.raw(["merge", "--abort"]).catch(() => {
+          });
+          await git.raw(["rebase", "--abort"]).catch(() => {
+          });
+          await git.raw(["cherry-pick", "--abort"]).catch(() => {
+          });
+        }
         return {
           success: false,
           merged: false,
-          error: "Merge conflicts detected",
-          conflicts: this.parseConflictsFromError(err.message || "")
+          strategy,
+          filesChanged,
+          conflicts: conflicts2,
+          conflictState,
+          cleanup: emptyCleanup,
+          error: "Merge conflicts detected"
         };
       }
       return {
         success: false,
         merged: false,
+        strategy,
+        filesChanged,
+        conflicts: [],
+        conflictState: "none",
+        cleanup: emptyCleanup,
         error: err.message || "Merge failed"
       };
     }
@@ -7379,6 +7443,16 @@ var WorktreeService = class {
       }
     }
     return conflicts2;
+  }
+  async getActiveConflictFiles(git, errorMessage) {
+    try {
+      const status = await git.status();
+      if (status.conflicted.length > 0) {
+        return [...new Set(status.conflicted)];
+      }
+    } catch {
+    }
+    return this.parseConflictsFromError(errorMessage);
   }
 };
 var RESERVED_OVERVIEW_CONTEXT = "overview";
@@ -9263,16 +9337,27 @@ function getMergeTools(workspaceRoot) {
             enum: ["merge", "squash", "rebase"],
             description: "Merge strategy (default: merge)"
           },
-          message: { type: "string", description: "Optional merge commit message for merge/squash only. Empty uses default." }
+          message: { type: "string", description: "Optional merge commit message for merge/squash only. Empty uses default." },
+          preserveConflicts: {
+            type: "boolean",
+            description: "Keep merge conflict state intact instead of auto-aborting (default: false)."
+          },
+          cleanup: {
+            type: "string",
+            enum: ["none", "worktree", "worktree+branch"],
+            description: "Cleanup mode after a successful merge (default: none)."
+          }
         },
         required: ["feature", "task"]
       },
       invoke: async (input) => {
-        const { feature, task, strategy = "merge", message } = input;
-        const result = await worktreeService.merge(feature, task, strategy, message);
+        const { feature, task, strategy = "merge", message, preserveConflicts, cleanup } = input;
+        const result = await worktreeService.merge(feature, task, strategy, message, {
+          preserveConflicts,
+          cleanup
+        });
         return JSON.stringify({
-          success: result.success,
-          strategy,
+          ...result,
           message: result.success ? "Merge completed." : result.error || "Merge failed."
         });
       }

--- a/packages/vscode-hive/package.json
+++ b/packages/vscode-hive/package.json
@@ -364,7 +364,7 @@
       {
         "name": "hive_merge",
         "displayName": "Merge Task Branch",
-        "modelDescription": "Merge a completed task branch into current branch. Supports merge, squash, or rebase strategies. Use after hive_exec_complete to integrate changes.",
+        "modelDescription": "Merge a completed task branch into current branch. Supports merge, squash, or rebase strategies. Use after hive_worktree_commit to integrate changes.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "hiveMerge",
         "inputSchema": {

--- a/packages/vscode-hive/package.json
+++ b/packages/vscode-hive/package.json
@@ -390,6 +390,19 @@
             "message": {
               "type": "string",
               "description": "Optional merge commit message for merge/squash only. Empty uses default."
+            },
+            "preserveConflicts": {
+              "type": "boolean",
+              "description": "Keep merge conflict state intact instead of auto-aborting (default: false)."
+            },
+            "cleanup": {
+              "type": "string",
+              "enum": [
+                "none",
+                "worktree",
+                "worktree+branch"
+              ],
+              "description": "Cleanup mode after a successful merge (default: none)."
             }
           },
           "required": [

--- a/packages/vscode-hive/src/tools/merge.test.ts
+++ b/packages/vscode-hive/src/tools/merge.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { WorktreeService } from 'hive-core';
+import { getMergeTools } from './merge';
+
+const TEST_ROOT_BASE = `/tmp/vscode-hive-merge-test-${process.pid}`;
+
+describe('getMergeTools', () => {
+  let testRoot: string;
+
+  beforeEach(() => {
+    fs.rmSync(TEST_ROOT_BASE, { recursive: true, force: true });
+    fs.mkdirSync(TEST_ROOT_BASE, { recursive: true });
+    testRoot = fs.mkdtempSync(path.join(TEST_ROOT_BASE, 'workspace-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEST_ROOT_BASE, { recursive: true, force: true });
+  });
+
+  it('registers helper-friendly merge inputs and result payload', async () => {
+    const tool = getMergeTools(testRoot).find(candidate => candidate.name === 'hive_merge');
+    if (!tool) {
+      throw new Error('hive_merge tool not found');
+    }
+
+    expect(tool.inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        feature: { type: 'string', description: 'Feature name' },
+        task: { type: 'string', description: 'Task folder name' },
+        strategy: {
+          type: 'string',
+          enum: ['merge', 'squash', 'rebase'],
+          description: 'Merge strategy (default: merge)',
+        },
+        message: {
+          type: 'string',
+          description: 'Optional merge commit message for merge/squash only. Empty uses default.',
+        },
+        preserveConflicts: {
+          type: 'boolean',
+          description: 'Keep merge conflict state intact instead of auto-aborting (default: false).',
+        },
+        cleanup: {
+          type: 'string',
+          enum: ['none', 'worktree', 'worktree+branch'],
+          description: 'Cleanup mode after a successful merge (default: none).',
+        },
+      },
+      required: ['feature', 'task'],
+    });
+  });
+
+  it('returns the shared merge result contract plus a concise message', async () => {
+    const mergeTool = getMergeTools(testRoot).find(candidate => candidate.name === 'hive_merge');
+    if (!mergeTool) {
+      throw new Error('hive_merge tool not found');
+    }
+
+    const originalMerge = WorktreeService.prototype.merge;
+    WorktreeService.prototype.merge = async () => ({
+      success: true,
+      merged: true,
+      strategy: 'merge',
+      sha: 'abc123',
+      filesChanged: ['task-note.txt'],
+      conflicts: [],
+      conflictState: 'none',
+      cleanup: {
+        worktreeRemoved: true,
+        branchDeleted: false,
+        pruned: true,
+      },
+    });
+
+    try {
+      const output = JSON.parse(await mergeTool.invoke({
+        feature: 'demo',
+        task: '01-task',
+        strategy: 'merge',
+        cleanup: 'worktree',
+      }, {} as any)) as Record<string, unknown>;
+
+      expect(output).toEqual({
+        success: true,
+        merged: true,
+        strategy: 'merge',
+        sha: 'abc123',
+        filesChanged: ['task-note.txt'],
+        conflicts: [],
+        conflictState: 'none',
+        cleanup: {
+          worktreeRemoved: true,
+          branchDeleted: false,
+          pruned: true,
+        },
+        message: 'Merge completed.',
+      });
+    } finally {
+      WorktreeService.prototype.merge = originalMerge;
+    }
+  });
+
+  it('registers hive_merge metadata in package.json', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf-8')
+    ) as {
+      contributes?: {
+        languageModelTools?: Array<{
+          name?: string;
+          toolReferenceName?: string;
+          inputSchema?: {
+            properties?: Record<string, { enum?: string[] }>;
+          };
+        }>;
+      };
+    };
+
+    const mergeTool = packageJson.contributes?.languageModelTools?.find(tool => tool.name === 'hive_merge');
+
+    expect(mergeTool?.toolReferenceName).toBe('hiveMerge');
+    expect(mergeTool?.inputSchema?.properties).toHaveProperty('preserveConflicts');
+    expect(mergeTool?.inputSchema?.properties?.cleanup?.enum).toEqual([
+      'none',
+      'worktree',
+      'worktree+branch',
+    ]);
+  });
+});

--- a/packages/vscode-hive/src/tools/merge.ts
+++ b/packages/vscode-hive/src/tools/merge.ts
@@ -24,20 +24,33 @@ export function getMergeTools(workspaceRoot: string): ToolRegistration[] {
             description: 'Merge strategy (default: merge)',
           },
           message: { type: 'string', description: 'Optional merge commit message for merge/squash only. Empty uses default.' },
+          preserveConflicts: {
+            type: 'boolean',
+            description: 'Keep merge conflict state intact instead of auto-aborting (default: false).',
+          },
+          cleanup: {
+            type: 'string',
+            enum: ['none', 'worktree', 'worktree+branch'],
+            description: 'Cleanup mode after a successful merge (default: none).',
+          },
         },
         required: ['feature', 'task'],
       },
       invoke: async (input) => {
-        const { feature, task, strategy = 'merge', message } = input as {
+        const { feature, task, strategy = 'merge', message, preserveConflicts, cleanup } = input as {
           feature: string;
           task: string;
           strategy?: string;
           message?: string;
+          preserveConflicts?: boolean;
+          cleanup?: 'none' | 'worktree' | 'worktree+branch';
         };
-        const result = await worktreeService.merge(feature, task, strategy as any, message);
+        const result = await worktreeService.merge(feature, task, strategy as any, message, {
+          preserveConflicts,
+          cleanup,
+        });
         return JSON.stringify({
-          success: result.success,
-          strategy,
+          ...result,
           message: result.success
             ? 'Merge completed.'
             : result.error || 'Merge failed.',


### PR DESCRIPTION
## Summary
- add the runtime-only `hive-helper` merge recovery agent and keep it out of custom/generated agent surfaces
- extend `hive_merge` and merge/worktree contracts across hive-core, opencode-hive, and vscode-hive for isolated cleanup/conflict recovery
- teach Hive/Swarm to delegate merge batches to `hive-helper`, add focused coverage, and clean up review-follow-up docs/metadata inconsistencies

## Notes
- Stacked PR for #72 on top of `feature/context-model-clarification` to keep this slice narrow.

## Test Plan
- [x] `bun run build`
- [x] `bun run test`