### PR TITLE
feat: align Copilot askQuestions parity across generated artifacts

### DIFF
--- a/packages/hive-core/templates/skills/copilot-agent.md
+++ b/packages/hive-core/templates/skills/copilot-agent.md
@@ -114,7 +114,7 @@ The `**Depends on**:` annotation declares task execution order:
 - `**Depends on**: 1, 3` — Depends on tasks 1 and 3
 - *(omitted)* — Implicit sequential, depends on previous task (N-1)
 
-When multiple tasks are runnable, ask the user whether to run them in parallel or sequentially.
+When multiple tasks are runnable, prefer `vscode/askQuestions` for the structured parallel/sequential decision. Fall back to plain Copilot chat only when `vscode/askQuestions` is unavailable or a lightweight follow-up is enough.
 
 ## Example Interaction
 
@@ -139,4 +139,4 @@ When multiple tasks are runnable, ask the user whether to run them in parallel o
 
 ## Communication
 
-- Use Copilot's built-in clarification flow in chat. In prompt files, use `vscode/askQuestions` only when structured follow-up materially helps.
+- Prefer `vscode/askQuestions` for structured clarification and approval checkpoints. Fall back to plain Copilot chat only when `vscode/askQuestions` is unavailable or a lightweight follow-up is enough.

--- a/packages/vscode-hive/src/__tests__/generators.test.ts
+++ b/packages/vscode-hive/src/__tests__/generators.test.ts
@@ -72,7 +72,19 @@ describe('Agent Generators', () => {
     const hive = generateHiveAgent(opts);
     const frontmatter = extractFrontmatter(hive);
     expect(frontmatter).toContain('- agent');
+    expect(frontmatter).toContain('- vscode/askQuestions');
     expect(frontmatter).toContain('agents:');
+  });
+
+  test('hive agent uses askQuestions-first wording without leaking question()', () => {
+    const hive = generateHiveAgent(opts);
+    const body = getBody(hive);
+
+    expect(body).toContain('Use `vscode/askQuestions` for structured decision checkpoints');
+    expect(body).toContain('Plain chat is allowed only for lightweight clarification or when `vscode/askQuestions` is unavailable');
+    expect(body).not.toContain('Ask the user directly in chat');
+    expect(body).not.toContain('ask the user directly in chat');
+    expect(body).not.toContain('question()');
   });
 
   test('individual agent generators return content', () => {

--- a/packages/vscode-hive/src/__tests__/generators.test.ts
+++ b/packages/vscode-hive/src/__tests__/generators.test.ts
@@ -14,7 +14,7 @@ import {
   generateHiveWorkflowInstructions,
 } from '../generators/instructions.js';
 import { generatePluginManifest } from '../generators/plugin.js';
-import { generateAllPrompts } from '../generators/prompts.js';
+import { generateAllPrompts, generatePlanFeaturePrompt } from '../generators/prompts.js';
 import { generateSkillFile, getBuiltinSkills } from '../generators/skills.js';
 
 function extractFrontmatter(content: string): string {
@@ -174,6 +174,9 @@ describe('Instruction Generators', () => {
     const body = getBody(content);
     expect(body).toContain('AGENTS.md');
     expect(body).toContain('.github/prompts/');
+    expect(body).toContain('vscode/askQuestions');
+    expect(body).toContain('plain chat only as a fallback');
+    expect(body).not.toContain('inside prompt files only');
     expect(body.length).toBeLessThanOrEqual(1000);
   });
 });
@@ -198,6 +201,17 @@ describe('Prompt Generators', () => {
       expect(frontmatter).toContain('model:');
       expect(frontmatter).toContain('tools:');
     }
+  });
+
+  test('plan feature prompt includes structured clarification tool parity', () => {
+    const prompt = generatePlanFeaturePrompt();
+    const frontmatter = extractFrontmatter(prompt.body);
+    const body = getBody(prompt.body);
+
+    expect(frontmatter).toContain('- "vscode/askQuestions"');
+    expect(body).toContain('vscode/askQuestions');
+    expect(body).toContain('plain chat only as a fallback');
+    expect(body).not.toContain('question()');
   });
 });
 

--- a/packages/vscode-hive/src/__tests__/generators.test.ts
+++ b/packages/vscode-hive/src/__tests__/generators.test.ts
@@ -115,6 +115,18 @@ describe('Skill Generators', () => {
     expect(extractFrontmatter(content)).toContain('name: sample-skill');
     expect(getBody(content)).toContain('# Heading');
   });
+
+  test('copilot skill output prefers askQuestions for runnable-task and approval checkpoints', () => {
+    const byName = new Map(getBuiltinSkills().map((skill) => [skill.name, getBody(skill.content)]));
+    const executingPlans = byName.get('executing-plans') ?? '';
+    const dispatchingParallelAgents = byName.get('dispatching-parallel-agents') ?? '';
+
+    expect(executingPlans).toContain('Prefer `vscode/askQuestions` for a structured choice');
+    expect(executingPlans).toContain('prefer `vscode/askQuestions` to ask whether the user wants a Hygienic code review');
+    expect(dispatchingParallelAgents).toContain('Prefer `vscode/askQuestions` for the approval prompt');
+    expect(executingPlans).not.toContain('question()');
+    expect(dispatchingParallelAgents).not.toContain('question()');
+  });
 });
 
 describe('Hook Generators', () => {

--- a/packages/vscode-hive/src/commands/initNest.test.ts
+++ b/packages/vscode-hive/src/commands/initNest.test.ts
@@ -116,7 +116,10 @@ describe('initNest', () => {
     ]);
 
     assert.match(readFile(projectRoot, '.github/copilot-instructions.md'), /AGENTS\.md/);
+    assert.match(readFile(projectRoot, '.github/copilot-instructions.md'), /vscode\/askQuestions/);
+    assert.match(readFile(projectRoot, '.github/copilot-instructions.md'), /plain chat only as a fallback/);
     assert.match(readFile(projectRoot, '.github/prompts/plan-feature.prompt.md'), /hive_plan_write/);
+    assert.match(readFile(projectRoot, '.github/prompts/plan-feature.prompt.md'), /vscode\/askQuestions/);
 
     const plugin = JSON.parse(readFile(projectRoot, 'plugin.json')) as { agents: string[]; hooks: string[]; instructions: string[] };
     assert.deepEqual(plugin.agents, ['.github/agents']);

--- a/packages/vscode-hive/src/commands/initNest.test.ts
+++ b/packages/vscode-hive/src/commands/initNest.test.ts
@@ -118,6 +118,15 @@ describe('initNest', () => {
     assert.match(readFile(projectRoot, '.github/copilot-instructions.md'), /AGENTS\.md/);
     assert.match(readFile(projectRoot, '.github/prompts/plan-feature.prompt.md'), /hive_plan_write/);
 
+    const executingPlansSkill = readFile(projectRoot, '.github/skills/executing-plans/SKILL.md');
+    assert.match(executingPlansSkill, /Prefer `vscode\/askQuestions` for a structured choice/);
+    assert.match(executingPlansSkill, /prefer `vscode\/askQuestions` to ask whether the user wants a Hygienic code review/);
+    assert.doesNotMatch(executingPlansSkill, /question\(\)/);
+
+    const dispatchingParallelAgentsSkill = readFile(projectRoot, '.github/skills/dispatching-parallel-agents/SKILL.md');
+    assert.match(dispatchingParallelAgentsSkill, /Prefer `vscode\/askQuestions` for the approval prompt/);
+    assert.doesNotMatch(dispatchingParallelAgentsSkill, /question\(\)/);
+
     const plugin = JSON.parse(readFile(projectRoot, 'plugin.json')) as { agents: string[]; hooks: string[]; instructions: string[] };
     assert.deepEqual(plugin.agents, ['.github/agents']);
     assert.deepEqual(plugin.hooks, ['.github/hooks/*']);

--- a/packages/vscode-hive/src/generators/agents.test.ts
+++ b/packages/vscode-hive/src/generators/agents.test.ts
@@ -29,21 +29,26 @@ describe('generateAllAgents', () => {
 
   it('maps tool names and removes opencode-specific references from the hive agent', () => {
     const hive = byFilename.get('hive.agent.md');
+    const body = getBody(hive ?? '');
 
     expect(hive).toContain("- tctinh.vscode-hive/*");
+    expect(hive).toContain('- vscode/askQuestions');
     expect(hive).toContain('use the agent tool to invoke @scout');
     expect(hive).toContain('refer to the skill at .github/skills/parallel-exploration/');
-    expect(hive).toContain('ask the user directly in chat');
     expect(hive).toContain('.github/prompts/');
     expect(hive).toContain('.github/copilot-instructions.md');
     expect(hive).toContain('AGENTS.md');
     expect(hive).toContain('vscode/askQuestions');
     expect(hive).toContain('Playwright MCP');
     expect(hive).toContain('browser tools');
+    expect(body).toContain('Use `vscode/askQuestions` for structured decision checkpoints');
+    expect(body).toContain('Plain chat is allowed only for lightweight clarification or when `vscode/askQuestions` is unavailable');
 
     expect(hive).not.toContain('question()');
     expect(hive).not.toContain('task({ subagent_type: "scout-researcher" })');
     expect(hive).not.toContain('hive_skill(');
+    expect(body).not.toContain('Ask the user directly in chat');
+    expect(body).not.toContain('ask the user directly in chat');
     // Check OpenCode-specific tool names as tool references (backticked), not as English prose
     expect(hive).not.toContain('`Bash`');
     expect(hive).not.toContain('`Read`');

--- a/packages/vscode-hive/src/generators/agents.ts
+++ b/packages/vscode-hive/src/generators/agents.ts
@@ -47,7 +47,7 @@ Intent Verbalization — verbalize before acting:
 | "Quick change" | Trivial | Act directly |
 | "Add new flow" | Complex | Plan/delegate |
 | "Where is X?" | Research | Scout exploration |
-| "Should we…?" | Ambiguous | Ask the user directly in chat |
+| "Should we…?" | Ambiguous | Use \`vscode/askQuestions\` for the decision checkpoint |
 
 ### Canonical Delegation Threshold
 - Delegate to Scout when you cannot name the file path upfront, expect to inspect 2+ files, or the question is open-ended ("how/where does X work?").
@@ -89,10 +89,14 @@ Before major transitions, verify:
 - [ ] Scope defined?
 - [ ] No critical ambiguities?
 
+Use \`vscode/askQuestions\` for structured decision checkpoints such as ambiguity resolution, review approval, parallelization approval, blocker recovery, and batch review confirmation.
+Plain chat is allowed only for lightweight clarification or when \`vscode/askQuestions\` is unavailable.
+
 ### Turn Termination
 Valid endings:
-- Ask a concrete question directly in chat
-- Update draft + ask a concrete question directly in chat
+- Use \`vscode/askQuestions\` for a concrete structured decision checkpoint
+- Update draft + use \`vscode/askQuestions\` for the next structured decision checkpoint
+- Ask a lightweight clarification in chat only when it does not need structured options
 - Explicitly state you are waiting on tool or subagent work
 - Auto-transition to the next required action
 
@@ -173,7 +177,7 @@ Refresh \`context/overview.md\` as the primary human-facing review surface, whil
 - Never require Mermaid.
 
 ### After Plan Written
-Ask the user directly in chat whether they want a Hygienic review.
+Use \`vscode/askQuestions\` to ask whether they want a Hygienic review.
 
 If yes → default to built-in @hygienic; choose a configured reviewer only when its description is a better match. Then use the agent tool to invoke @hygienic to review the plan.
 
@@ -194,7 +198,7 @@ Search stop conditions: enough context, repeated info, 2 rounds with no new data
 ### Task Dependencies (Always Check)
 Use \`hive_status()\` to see runnable tasks and blockedBy info.
 - Only start tasks from the runnable list
-- When 2+ tasks are runnable: ask the user directly in chat before parallelizing
+- When 2+ tasks are runnable: use \`vscode/askQuestions\` before parallelizing
 - Record execution decisions with \`hive_context_write({ name: "execution-decisions", ... })\`
 
 ### When to Load Skills
@@ -217,12 +221,12 @@ hive_worktree_create({ task: "01-task-name" })
 3. Use \`continueFrom: "blocked"\` only when status is exactly \`blocked\`
 4. If status is not \`blocked\`, do not use \`continueFrom: "blocked"\`; use normal worktree start/resume workflows for \`pending\` / \`in_progress\` tasks
 5. Never loop \`continueFrom: "blocked"\` on non-blocked statuses
-6. If a task is blocked: read blocker info → ask the user directly in chat → resume with \`continueFrom: "blocked"\`
+6. If a task is blocked: read blocker info → use \`vscode/askQuestions\` to present the decision → resume with \`continueFrom: "blocked"\`
 7. Skip polling — the result is available when the worker returns
 
 ### Batch Merge + Verify Workflow
 When multiple tasks are in flight, prefer **batch completion** over per-task verification:
-1. Dispatch a batch of runnable tasks (ask the user before parallelizing).
+1. Dispatch a batch of runnable tasks (use \`vscode/askQuestions\` before parallelizing).
 2. Wait for all workers to finish.
 3. Merge each completed task branch into the current branch.
 4. Run full verification once on the merged batch.
@@ -232,11 +236,11 @@ When multiple tasks are in flight, prefer **batch completion** over per-task ver
 1. Stop all further edits
 2. Revert to last known working state
 3. Document what was attempted
-4. Ask the user directly in chat — present options and context
+4. Use \`vscode/askQuestions\` to present options and context
 
 ### Post-Batch Review (Hygienic)
 After completing and merging a batch:
-1. Ask the user directly in chat if they want a Hygienic code review for the batch.
+1. Use \`vscode/askQuestions\` to ask if they want a Hygienic code review for the batch.
 2. If yes → default to built-in @hygienic; choose a configured reviewer only when its description is a better match.
 3. Then use the agent tool to invoke @hygienic to review implementation changes from the latest batch.
 4. Apply feedback before starting the next batch.
@@ -253,7 +257,7 @@ For projects without AGENTS.md:
 ### Orchestration Iron Laws
 - Delegate by default
 - Verify all work completes
-- Ask the user directly in chat for user input
+- Use \`vscode/askQuestions\` for structured user input checkpoints
 
 ---
 
@@ -278,7 +282,7 @@ Do not violate:
 
 Blocking violations:
 - Ending a turn without a next action
-- Asking for user input indirectly or vaguely
+- Relying on plain or vague chat for structured decision checkpoints
 `;
 
 const scoutBody = `# Scout (Explorer/Researcher/Retrieval)
@@ -628,6 +632,7 @@ export function generateHiveAgent(opts: AgentGeneratorOptions): string {
       '  - fetch',
       '  - codebase',
       '  - usages',
+      '  - vscode/askQuestions',
       `  - ${opts.extensionId}/*`,
       'agents:',
       '  - scout',

--- a/packages/vscode-hive/src/generators/copilot-template.test.ts
+++ b/packages/vscode-hive/src/generators/copilot-template.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const templatePath = path.join(packageRoot, 'hive-core', 'templates', 'skills', 'copilot-agent.md');
+
+describe('copilot skill template', () => {
+  it('keeps askQuestions as the default structured path with chat-only fallback guidance', () => {
+    const template = fs.readFileSync(templatePath, 'utf8');
+
+    expect(template).toContain('prefer `vscode/askQuestions` for the structured parallel/sequential decision');
+    expect(template).toContain('Fall back to plain Copilot chat only when `vscode/askQuestions` is unavailable');
+    expect(template).toContain('Prefer `vscode/askQuestions` for structured clarification and approval checkpoints.');
+    expect(template).not.toContain('use `vscode/askQuestions` only when structured follow-up materially helps');
+  });
+});

--- a/packages/vscode-hive/src/generators/instructions.test.ts
+++ b/packages/vscode-hive/src/generators/instructions.test.ts
@@ -63,8 +63,11 @@ describe('instructions generator', () => {
     expect(body).toContain('AGENTS.md');
     expect(body).toContain('.github/instructions/');
     expect(body).toContain('.github/prompts/');
+    expect(body).toContain('vscode/askQuestions');
+    expect(body).toContain('plain chat only as a fallback');
     expect(body).toContain('built-in browser tools');
     expect(body).toContain('MCP');
+    expect(body).not.toContain('inside prompt files only');
     expect(body).not.toContain('question()');
     expect(body.length).toBeLessThanOrEqual(1000);
   });

--- a/packages/vscode-hive/src/generators/instructions.ts
+++ b/packages/vscode-hive/src/generators/instructions.ts
@@ -65,7 +65,7 @@ export function generateCopilotInstructions(): string {
 
 Use .github/instructions/ for path-specific coding and workflow guidance, and .github/prompts/ for reusable entry points such as plan creation, plan review, execution, review handoff, and completion verification.
 
-Prefer GitHub Copilot's built-in clarification flow in chat. Use vscode/askQuestions inside prompt files only when extra structured input materially improves the result.
+Use vscode/askQuestions for practical structured decision checkpoints wherever Copilot supports it. Use plain chat only as a fallback when the tool is unavailable or a truly lightweight clarification is better.
 
 When web research, browser inspection, or end-to-end verification is needed, prefer built-in browser tools and MCP integrations such as Playwright MCP over extension-specific substitutes.`,
   );

--- a/packages/vscode-hive/src/generators/prompts.test.ts
+++ b/packages/vscode-hive/src/generators/prompts.test.ts
@@ -40,12 +40,16 @@ describe('prompt generator', () => {
   it('guides planning and review prompts toward current Copilot flows', () => {
     const planPrompt = generators.generatePlanFeaturePrompt();
     const reviewPrompt = generators.generateReviewPlanPrompt();
+    const planBody = getBody(planPrompt.body);
 
-    expect(getBody(planPrompt.body)).toContain('vscode/askQuestions');
-    expect(getBody(planPrompt.body)).toContain('hive_plan_write');
-    expect(getBody(planPrompt.body)).toContain('read-only');
-    expect(getBody(planPrompt.body)).toContain('AGENTS.md');
-    expect(getBody(planPrompt.body)).not.toContain('question()');
+    expect(planPrompt.body).toContain('  - "vscode/askQuestions"');
+    expect(planBody).toContain('vscode/askQuestions');
+    expect(planBody).toContain('hive_plan_write');
+    expect(planBody).toContain('read-only');
+    expect(planBody).toContain('AGENTS.md');
+    expect(planBody).toContain('plain chat only as a fallback');
+    expect(planBody).not.toContain('prefer Copilot\'s built-in clarification flow in chat');
+    expect(planBody).not.toContain('question()');
 
     expect(getBody(reviewPrompt.body)).toContain('hive_plan_read');
     expect(getBody(reviewPrompt.body)).toContain('approval');

--- a/packages/vscode-hive/src/generators/prompts.ts
+++ b/packages/vscode-hive/src/generators/prompts.ts
@@ -34,11 +34,11 @@ export function generatePlanFeaturePrompt(): PromptFile {
       description: 'Create or revise a Hive feature plan with plan-first guardrails.',
       agent: 'hive',
       model: 'gpt-5.4',
-      tools: ['read', 'search', 'codebase', 'usages', `${EXTENSION_ID}/hiveStatus`, `${EXTENSION_ID}/hivePlanWrite`],
+      tools: ['read', 'search', 'codebase', 'usages', 'vscode/askQuestions', `${EXTENSION_ID}/hiveStatus`, `${EXTENSION_ID}/hivePlanWrite`],
     },
     `Start by checking AGENTS.md, .github/copilot-instructions.md, and any relevant .github/instructions/ files. Use read-only exploration first, then write or revise the plan with hive_plan_write.
 
-If key requirements are missing, use vscode/askQuestions only for the minimum structured clarification needed; otherwise prefer Copilot's built-in clarification flow in chat.
+If key requirements are missing, use vscode/askQuestions as the normal structured clarification path for the minimum practical decision checkpoints. Use plain chat only as a fallback when the tool is unavailable or a truly lightweight clarification is better.
 
 Keep Hive's plan-first contract intact: no implementation edits, explicit task dependencies, exact file references, and concrete verification commands.`,
   );

--- a/packages/vscode-hive/src/generators/skills.test.ts
+++ b/packages/vscode-hive/src/generators/skills.test.ts
@@ -23,6 +23,7 @@ describe('skills generator', () => {
     const parallelExploration = byName.get('parallel-exploration');
     const writingPlans = byName.get('writing-plans');
     const executingPlans = byName.get('executing-plans');
+    const dispatchingParallelAgents = byName.get('dispatching-parallel-agents');
 
     expect(parallelExploration).toContain('Invoke the @scout agent via the agent tool');
     expect(parallelExploration).not.toContain('task(');
@@ -31,9 +32,15 @@ describe('skills generator', () => {
     expect(writingPlans).toContain('Refer to the skill at .github/skills/executing-plans/SKILL.md');
     expect(writingPlans).not.toContain('hive_skill:executing-plans');
 
-    expect(executingPlans).toContain('ask the user directly in chat');
+    expect(executingPlans).toContain('Prefer `vscode/askQuestions` for a structured choice');
+    expect(executingPlans).toContain('Fall back to asking directly in chat only when `vscode/askQuestions` is unavailable');
+    expect(executingPlans).toContain('prefer `vscode/askQuestions` to ask whether the user wants a Hygienic code review');
     expect(executingPlans).toContain('Refer to the skill at .github/skills/verification-before-completion/SKILL.md');
     expect(executingPlans).not.toContain('question()');
+
+    expect(dispatchingParallelAgents).toContain('Prefer `vscode/askQuestions` for the approval prompt');
+    expect(dispatchingParallelAgents).toContain('Fall back to asking directly in chat only when `vscode/askQuestions` is unavailable');
+    expect(dispatchingParallelAgents).not.toContain('question()');
   });
 
   it('includes overview-first context guidance in writing-plans', () => {

--- a/packages/vscode-hive/src/generators/skills.ts
+++ b/packages/vscode-hive/src/generators/skills.ts
@@ -261,7 +261,8 @@ Use \`hive_status()\` to get the **runnable** list — tasks with all dependenci
 Only \`done\` satisfies dependencies (not \`blocked\`, \`failed\`, \`partial\`, \`cancelled\`).
 
 **When 2+ tasks are runnable:**
-- Ask the user directly in chat: "Multiple tasks are runnable: [list]. Run in parallel, sequential, or a specific subset?"
+- Prefer \`vscode/askQuestions\` for a structured choice: "Multiple tasks are runnable: [list]. Run in parallel, sequential, or a specific subset?"
+- Fall back to asking directly in chat only when \`vscode/askQuestions\` is unavailable or a lightweight follow-up is enough
 - Record the decision with \`hive_context_write({ name: "execution-decisions", content: "..." })\` for future reference
 
 **When 1 task is runnable:** Proceed directly.
@@ -282,7 +283,8 @@ When batch complete:
 
 ### Step 4.5: Post-Batch Hygienic Review
 
-After the batch report, ask the user directly in chat if they want a Hygienic code review for the batch.
+After the batch report, prefer \`vscode/askQuestions\` to ask whether the user wants a Hygienic code review for the batch.
+Fall back to asking directly in chat only when \`vscode/askQuestions\` is unavailable or a lightweight follow-up is enough.
 If yes, invoke the @hygienic agent via the agent tool to review implementation changes from the latest batch, then apply feedback before starting the next batch.
 
 ### Step 5: Continue
@@ -594,7 +596,8 @@ Before dispatching, use \`hive_status()\` to get the **runnable** list — tasks
 Only \`done\` satisfies dependencies (not \`blocked\`, \`failed\`, \`partial\`, \`cancelled\`).
 
 **Ask the operator first:**
-- Ask the operator directly in chat: "These tasks are runnable and independent: [list]. Execute in parallel?"
+- Prefer \`vscode/askQuestions\` for the approval prompt: "These tasks are runnable and independent: [list]. Execute in parallel?"
+- Fall back to asking directly in chat only when \`vscode/askQuestions\` is unavailable or a lightweight follow-up is enough
 - Record the decision with \`hive_context_write({ name: "execution-decisions", content: "..." })\`
 - Proceed only after operator approval
 


### PR DESCRIPTION
## Summary
- align generated Copilot Hive agent output with `vscode/askQuestions`-first wording and structured decision checkpoints
- update prompt, instruction, and skill generators so the generated Copilot surfaces use consistent askQuestions guidance and tool exposure
- add regression coverage across generators and initNest scaffolding to lock the parity contract in place

## Test Plan
- updated regression coverage in `packages/vscode-hive/src/__tests__/generators.test.ts`
- updated generator tests in `packages/vscode-hive/src/generators/{agents,instructions,prompts,skills,copilot-template}.test.ts`
- updated `packages/vscode-hive/src/commands/initNest.test.ts`