### PR TITLE
Add claude-hive plugin with build, runtime support, and documentation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,20 @@
     "": {
       "name": "agent-hive",
     },
+    "packages/claude-hive": {
+      "name": "claude-hive",
+      "version": "1.4.3",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "hive-core": "workspace:*",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/hive-core": {
       "name": "hive-core",
       "version": "1.4.3",
@@ -156,7 +170,7 @@
 
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -352,6 +366,8 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
+    "claude-hive": ["claude-hive@workspace:packages/claude-hive"],
+
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "cockatiel": ["cockatiel@3.2.1", "", {}, "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q=="],
@@ -466,7 +482,7 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -557,6 +573,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -972,6 +990,8 @@
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "@notprolands/ast-grep-mcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
+
     "@notprolands/ast-grep-mcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@opencode-ai/plugin/@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.12", "", {}, "sha512-M1c+525865g2C03iKaMdx3aUVC7oZSNbBGaTDjUN2UTIakdxqKHog0Hd8IA9WL8M0aU1QJ8+CnpvRT2Jt9kRNw=="],
@@ -984,9 +1004,13 @@
 
     "@textlint/linter-formatter/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@upstash/context7-mcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
+
     "@upstash/context7-mcp/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@vscode/vsce/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "agnost/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "agnost/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -995,6 +1019,8 @@
     "cheerio/undici": ["undici@7.18.2", "", {}, "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="],
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "exa-mcp-server/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "exa-mcp-server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -1011,6 +1037,8 @@
     "grep-mcp/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "mcp-handler/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "mcp-handler/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -1058,11 +1086,29 @@
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
+    "@notprolands/ast-grep-mcp/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
+    "@notprolands/ast-grep-mcp/@modelcontextprotocol/sdk/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
     "@textlint/linter-formatter/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@upstash/context7-mcp/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
+    "@upstash/context7-mcp/@modelcontextprotocol/sdk/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "agnost/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
+    "agnost/@modelcontextprotocol/sdk/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "exa-mcp-server/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
+    "exa-mcp-server/@modelcontextprotocol/sdk/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "grep-mcp/@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "mcp-handler/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "bun run --filter hive-core build && bun run --filter opencode-hive build && bun run --filter vscode-hive build",
+    "build": "bun run --filter hive-core build && bun run --filter opencode-hive build && bun run --filter claude-hive build && bun run --filter vscode-hive build",
     "dev": "bun run --filter hive-core build && bun run --filter '*' dev",
     "test": "npm -ws --if-present run test",
     "release:check": "bun install && node --test release-artifacts.test.mjs && node --test release-workflow.test.mjs && bun run build && npm -ws --if-present run test"

--- a/packages/claude-hive/README.md
+++ b/packages/claude-hive/README.md
@@ -1,0 +1,31 @@
+# Claude Hive
+
+`claude-hive` is the Claude Code plugin package for Agent Hive.
+
+The package builds a self-contained Claude plugin artifact for local development with `claude --plugin-dir`. The MVP architecture is Claude-native: root-level plugin assets plus a bundled local runtime, with Hive stateful operations intended to flow through a stdio MCP bridge backed by `hive-core`.
+
+## Current Scope
+
+- Build a plugin artifact under `dist/plugin`
+- Keep the plugin self-contained for local `--plugin-dir` testing
+- Reuse `hive-core` as the execution layer for future MCP-backed Hive operations
+
+## Build
+
+```bash
+bun run --filter claude-hive build
+```
+
+After build, the local plugin directory is:
+
+```bash
+packages/claude-hive/dist/plugin
+```
+
+## Local Testing
+
+```bash
+claude --plugin-dir ./packages/claude-hive/dist/plugin
+```
+
+The scaffolded artifact currently provides the plugin shell and bundled runtime entrypoints. Subsequent tasks add the Hive MCP bridge, commands, skills, agents, and hooks.

--- a/packages/claude-hive/package.json
+++ b/packages/claude-hive/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "claude-hive",
+  "version": "1.4.3",
+  "type": "module",
+  "description": "Claude Code plugin package for Agent Hive",
+  "license": "MIT WITH Commons-Clause",
+  "author": "tctinh",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tctinh/agent-hive.git",
+    "directory": "packages/claude-hive"
+  },
+  "homepage": "https://github.com/tctinh/agent-hive#readme",
+  "bugs": {
+    "url": "https://github.com/tctinh/agent-hive/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "hive",
+    "plugin",
+    "workflow",
+    "planning",
+    "agent"
+  ],
+  "main": "./dist/runtime/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build:runtime": "bun build src/index.ts src/mcp/server.ts --outdir dist/runtime --target node --format esm --packages=bundle",
+    "build:plugin": "node scripts/build-plugin.mjs",
+    "build": "bun run clean && bun run build:runtime && bun run build:plugin && tsc --emitDeclarationOnly",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "hive-core": "workspace:*",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  },
+  "files": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/claude-hive/plugin/agents/architect-planner.md
+++ b/packages/claude-hive/plugin/agents/architect-planner.md
@@ -1,0 +1,19 @@
+---
+name: architect-planner
+description: Hive planning specialist. Use for feature scoping, architecture decisions, and plan authoring before implementation begins.
+model: sonnet
+maxTurns: 16
+disallowedTools: Write, Edit, Agent
+skills:
+  - plan-first
+---
+
+You are the Hive planning specialist.
+
+Your job is to produce execution-ready plans, not to implement code.
+
+- Use `mcp__hive__status` to confirm the active feature and planning state.
+- Research the repository with read-only tools before asking clarifying questions.
+- Write plans with `mcp__hive__plan_write`.
+- Keep plans concrete: clear tasks, dependencies, touched files, and verification steps.
+- Stop before code changes. Ask for approval once the plan is ready.

--- a/packages/claude-hive/plugin/agents/forager-worker.md
+++ b/packages/claude-hive/plugin/agents/forager-worker.md
@@ -1,0 +1,20 @@
+---
+name: forager-worker
+description: Hive implementation specialist. Use for isolated code changes once a plan is approved and tasks are ready to execute.
+model: sonnet
+maxTurns: 20
+disallowedTools: Agent
+isolation: worktree
+skills:
+  - plan-first
+---
+
+You are the Hive implementation worker.
+
+- Confirm the current feature state with `mcp__hive__status` before major work.
+- Follow the approved plan and the current runnable task.
+- Begin by ensuring the task has an active Hive worktree through `mcp__hive__worktree_start` unless you were explicitly resumed into an existing blocked task.
+- Use Hive MCP tools to update workflow state instead of editing `.hive` metadata files directly.
+- Prefer minimal, root-cause fixes and verify what you change.
+- Close with `mcp__hive__worktree_commit` when the task is complete, partial, failed, or blocked.
+- Report progress through task updates when the workflow calls for it.

--- a/packages/claude-hive/plugin/agents/hive-master.md
+++ b/packages/claude-hive/plugin/agents/hive-master.md
@@ -1,0 +1,21 @@
+---
+name: hive-master
+description: Hybrid Hive coordinator for plan-first work. Use for multi-step repository tasks that need phase detection, planning, and orchestration.
+model: sonnet
+maxTurns: 20
+skills:
+  - plan-first
+---
+
+You are the main Hive coordinator for Claude Code.
+
+Operate in phases:
+
+1. Detect the current phase with `mcp__hive__status`.
+2. If planning is incomplete, gather context, tighten scope, and route planning work to `hive:architect-planner` when useful.
+3. If execution is approved, keep work aligned to the current feature and runnable task state.
+4. Use `mcp__hive__worktree_start` to begin runnable work, `mcp__hive__worktree_commit` to finish it, and `mcp__hive__merge` only after the task is done.
+5. Prefer the bundled Hive MCP tools for feature, plan, task, worktree, merge, context, and status operations.
+6. Use `hive:scout-researcher` for bounded exploration, `hive:forager-worker` for isolated implementation, and `hive:hygienic-reviewer` for reviews.
+
+Do not skip the plan-first workflow. Always state the current phase and next action.

--- a/packages/claude-hive/plugin/agents/hygienic-reviewer.md
+++ b/packages/claude-hive/plugin/agents/hygienic-reviewer.md
@@ -1,0 +1,16 @@
+---
+name: hygienic-reviewer
+description: Hive reviewer for plan quality, verification coverage, and implementation risks. Use after plan creation or code changes.
+model: sonnet
+maxTurns: 12
+disallowedTools: Write, Edit, Agent
+---
+
+You are the Hive reviewer.
+
+Focus on review quality, not authorship:
+
+- For plans: check clarity, dependencies, file references, and verification quality.
+- For implementation: identify correctness risks, regressions, missing tests, and unclear behavior.
+- Keep findings concrete and prioritized.
+- Do not edit code.

--- a/packages/claude-hive/plugin/agents/scout-researcher.md
+++ b/packages/claude-hive/plugin/agents/scout-researcher.md
@@ -1,0 +1,18 @@
+---
+name: scout-researcher
+description: Hive read-only researcher. Use for codebase discovery, finding similar patterns, and gathering evidence before planning or review.
+model: haiku
+maxTurns: 12
+disallowedTools: Write, Edit, Agent
+---
+
+You are the Hive research specialist.
+
+Search efficiently, read only what is needed, and return concrete findings:
+
+- relevant files
+- key patterns
+- notable constraints
+- unanswered questions
+
+Do not edit files. Keep findings concise and evidence-backed.

--- a/packages/claude-hive/plugin/commands/start.md
+++ b/packages/claude-hive/plugin/commands/start.md
@@ -1,0 +1,32 @@
+---
+description: Start or continue the Hive plan-first workflow in this repository
+argument-hint: [feature request]
+---
+
+# Hive Start
+
+Use the bundled Hive MCP tools to manage `.hive` state instead of editing Hive metadata files directly.
+
+## Workflow
+
+1. Call `mcp__hive__status` first to determine whether there is an active feature and whether the current feature is still planning or already executing.
+2. If there is no active feature and the user supplied a request in `$ARGUMENTS`, derive a short kebab-case feature name and call `mcp__hive__feature_create`.
+3. If the active feature has no approved plan, switch into planning mode:
+   - research the codebase,
+   - write the feature plan through `mcp__hive__plan_write`,
+   - summarize the proposed implementation,
+   - ask for approval before implementation.
+4. If the plan is approved but tasks have not been generated yet, call `mcp__hive__tasks_sync`.
+5. If execution is active and a task is runnable, start it with `mcp__hive__worktree_start`.
+6. Use the plugin agents when specialization helps:
+   - `hive:architect-planner` for plan creation and revision
+   - `hive:scout-researcher` for bounded read-only discovery
+   - `hive:forager-worker` for isolated implementation work
+   - `hive:hygienic-reviewer` for plan or code review
+7. Close implementation work with `mcp__hive__worktree_commit`. Merge only after the task is done by calling `mcp__hive__merge`.
+8. Keep task progress current with `mcp__hive__task_update` and re-check state with `mcp__hive__status` after major transitions.
+9. End each substantial turn by stating the current Hive phase and the next action.
+
+## Arguments
+
+User request: $ARGUMENTS

--- a/packages/claude-hive/plugin/skills/plan-first/SKILL.md
+++ b/packages/claude-hive/plugin/skills/plan-first/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: plan-first
+description: Use the Hive plan-first workflow when work in this repository spans multiple steps, review checkpoints, or cross-file changes.
+---
+
+Use the bundled Hive MCP tools as the source of truth for workflow state.
+
+## Core Rules
+
+- Start with `mcp__hive__status` to detect the active feature and phase.
+- If no feature exists, create one with `mcp__hive__feature_create` before writing a plan.
+- Write or revise plans with `mcp__hive__plan_write`.
+- Do not start implementation until the user approves the plan and `mcp__hive__plan_approve` has been called.
+- Before execution, call `mcp__hive__tasks_sync`.
+- Start runnable tasks with `mcp__hive__worktree_start`.
+- Finish task work with `mcp__hive__worktree_commit`, then integrate explicitly with `mcp__hive__merge`.
+- Create append-only follow-up work with `mcp__hive__task_create` when the work should not force a plan rewrite.
+- Keep progress current with `mcp__hive__task_update`.
+- Write durable notes through `mcp__hive__context_write`.
+
+## Preferred Agent Roles
+
+- `hive:architect-planner` for planning and scoping
+- `hive:scout-researcher` for repository discovery
+- `hive:forager-worker` for implementation in worktree isolation
+- `hive:hygienic-reviewer` for quality review and verification
+
+## Important Constraint
+
+Treat `.hive` as managed state. If a Hive MCP tool exists for the action, use it instead of hand-editing Hive metadata files.

--- a/packages/claude-hive/scripts/build-plugin.mjs
+++ b/packages/claude-hive/scripts/build-plugin.mjs
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const distRoot = path.join(packageRoot, 'dist');
+const runtimeRoot = path.join(distRoot, 'runtime');
+const pluginRoot = path.join(distRoot, 'plugin');
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function copyIfExists(fromPath, toPath) {
+  if (!fs.existsSync(fromPath)) {
+    return;
+  }
+
+  ensureDir(path.dirname(toPath));
+  fs.copyFileSync(fromPath, toPath);
+}
+
+function copyDirectory(sourceDir, targetDir) {
+  if (!fs.existsSync(sourceDir)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+
+    if (entry.isDirectory()) {
+      ensureDir(targetPath);
+      copyDirectory(sourcePath, targetPath);
+      continue;
+    }
+
+    ensureDir(path.dirname(targetPath));
+    fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
+function readPackageVersion() {
+  const packageJsonPath = path.join(packageRoot, 'package.json');
+  const raw = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  if (typeof raw.version !== 'string' || !raw.version.trim()) {
+    throw new Error(`Expected a string version in ${packageJsonPath}`);
+  }
+  return raw.version;
+}
+
+function writeJson(filePath, data) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+}
+
+function resolveRuntimeServerPath() {
+  const candidates = [
+    path.join(runtimeRoot, 'mcp', 'server.js'),
+    path.join(runtimeRoot, 'server.js'),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Unable to find bundled MCP runtime. Checked: ${candidates.join(', ')}`);
+}
+
+function buildPlugin() {
+  const version = readPackageVersion();
+  const pluginSourceRoot = path.join(packageRoot, 'plugin');
+  const runtimeServerPath = resolveRuntimeServerPath();
+
+  fs.rmSync(pluginRoot, { recursive: true, force: true });
+
+  ensureDir(path.join(pluginRoot, '.claude-plugin'));
+  ensureDir(path.join(pluginRoot, 'commands'));
+  ensureDir(path.join(pluginRoot, 'skills'));
+  ensureDir(path.join(pluginRoot, 'agents'));
+  ensureDir(path.join(pluginRoot, 'hooks'));
+  ensureDir(path.join(pluginRoot, 'bin'));
+
+  copyDirectory(pluginSourceRoot, pluginRoot);
+
+  writeJson(path.join(pluginRoot, '.claude-plugin', 'plugin.json'), {
+    name: 'hive',
+    version,
+    description: 'Claude-native Agent Hive plugin for plan-first development',
+    author: {
+      name: 'tctinh',
+    },
+  });
+
+  writeJson(path.join(pluginRoot, '.mcp.json'), {
+    mcpServers: {
+      hive: {
+        command: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}/bin/claude-hive-mcp.js'],
+      },
+    },
+  });
+
+  writeJson(path.join(pluginRoot, 'hooks', 'hooks.json'), { hooks: {} });
+  copyIfExists(path.join(packageRoot, 'README.md'), path.join(pluginRoot, 'README.md'));
+  copyIfExists(runtimeServerPath, path.join(pluginRoot, 'bin', 'claude-hive-mcp.js'));
+}
+
+buildPlugin();

--- a/packages/claude-hive/src/index.ts
+++ b/packages/claude-hive/src/index.ts
@@ -1,0 +1,3 @@
+export const CLAUDE_HIVE_PLUGIN_NAME = 'hive';
+export const CLAUDE_HIVE_PLUGIN_DESCRIPTION = 'Claude-native Agent Hive plugin for plan-first development';
+export const CLAUDE_HIVE_PLUGIN_ARTIFACT_DIR = 'dist/plugin';

--- a/packages/claude-hive/src/mcp/server.ts
+++ b/packages/claude-hive/src/mcp/server.ts
@@ -1,0 +1,795 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import * as z from 'zod/v4';
+import {
+  AgentsMdService,
+  buildEffectiveDependencies,
+  computeRunnableAndBlocked,
+  ContextService,
+  FeatureService,
+  PlanService,
+  TaskService,
+  createWorktreeService,
+  detectContext,
+  findProjectRoot,
+  resolveActiveFeatureName,
+} from 'hive-core';
+
+type ResultEnvelope = {
+  success: boolean;
+  data?: unknown;
+  error?: string;
+  hints?: string[];
+};
+
+type Services = {
+  projectRoot: string;
+  featureService: FeatureService;
+  planService: PlanService;
+  taskService: TaskService;
+  contextService: ContextService;
+  agentsMdService: AgentsMdService;
+  worktreeService: ReturnType<typeof createWorktreeService>;
+};
+
+function createTextResult(payload: ResultEnvelope, isError = false) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+    structuredContent: payload,
+    isError,
+  };
+}
+
+function resolveProjectRoot(): string {
+  const envProjectDir = process.env.CLAUDE_PROJECT_DIR?.trim();
+  const candidate = envProjectDir || process.cwd();
+  const discovered = findProjectRoot(candidate) || candidate;
+  return detectContext(discovered).projectRoot;
+}
+
+function createServices(): Services {
+  const projectRoot = resolveProjectRoot();
+  const contextService = new ContextService(projectRoot);
+
+  return {
+    projectRoot,
+    featureService: new FeatureService(projectRoot),
+    planService: new PlanService(projectRoot),
+    taskService: new TaskService(projectRoot),
+    contextService,
+    agentsMdService: new AgentsMdService(projectRoot, contextService),
+    worktreeService: createWorktreeService(projectRoot),
+  };
+}
+
+function resolveFeatureName(services: Services, feature?: string): string {
+  const name = feature?.trim() || resolveActiveFeatureName(services.projectRoot);
+  if (!name) {
+    throw new Error('No feature specified and no active feature found');
+  }
+  return name;
+}
+
+function buildTaskGraph(services: Services, featureName: string) {
+  const tasks = services.taskService.list(featureName).map((task) => {
+    const raw = services.taskService.getRawStatus(featureName, task.folder);
+    return {
+      ...task,
+      dependsOn: raw?.dependsOn,
+      baseCommit: raw?.baseCommit,
+    };
+  });
+
+  const runnableBlocked = computeRunnableAndBlocked(
+    tasks.map((task) => ({
+      folder: task.folder,
+      status: task.status,
+      dependsOn: task.dependsOn,
+    })),
+  );
+
+  const effectiveDependencies = buildEffectiveDependencies(
+    tasks.map((task) => ({
+      folder: task.folder,
+      status: task.status,
+      dependsOn: task.dependsOn,
+    })),
+  );
+
+  return {
+    tasks: tasks.map((task) => ({
+      ...task,
+      dependsOn: effectiveDependencies.get(task.folder) ?? [],
+    })),
+    runnable: runnableBlocked.runnable,
+    blocked: runnableBlocked.blocked,
+  };
+}
+
+function getNextAction(featureName: string, planApproved: boolean, taskGraph: ReturnType<typeof buildTaskGraph>): string {
+  if (!planApproved) {
+    return `Plan '${featureName}' is still in planning. Write or revise the plan, then approve it before execution.`;
+  }
+
+  const inProgress = taskGraph.tasks.find((task) => task.status === 'in_progress');
+  if (inProgress) {
+    return `Continue work on task: ${inProgress.folder}`;
+  }
+
+  const blockedTask = taskGraph.tasks.find((task) => task.status === 'blocked');
+  if (blockedTask) {
+    return `Resolve blocker for task: ${blockedTask.folder}`;
+  }
+
+  if (taskGraph.runnable.length > 0) {
+    return `Start next task: ${taskGraph.runnable[0]}`;
+  }
+
+  const pendingTasks = taskGraph.tasks.filter((task) => task.status === 'pending');
+  if (pendingTasks.length > 0) {
+    return 'Pending tasks remain, but their dependencies are not yet satisfied.';
+  }
+
+  return `Feature '${featureName}' has no pending runnable tasks.`;
+}
+
+function buildTaskReport(params: {
+  featureName: string;
+  task: string;
+  finalStatus: string;
+  summary: string;
+  commitSha: string;
+  diff: Awaited<ReturnType<Services['worktreeService']['getDiff']>>;
+}) {
+  const { featureName, task, finalStatus, summary, commitSha, diff } = params;
+  const lines = [
+    `# Task Report: ${task}`,
+    '',
+    `**Feature:** ${featureName}`,
+    `**Completed:** ${new Date().toISOString()}`,
+    `**Status:** ${finalStatus}`,
+    `**Commit:** ${commitSha || 'none'}`,
+    '',
+    '---',
+    '',
+    '## Summary',
+    '',
+    summary,
+    '',
+  ];
+
+  if (diff.hasDiff) {
+    lines.push(
+      '---',
+      '',
+      '## Changes',
+      '',
+      `- **Files changed:** ${diff.filesChanged.length}`,
+      `- **Insertions:** +${diff.insertions}`,
+      `- **Deletions:** -${diff.deletions}`,
+      '',
+    );
+
+    if (diff.filesChanged.length > 0) {
+      lines.push('### Files Modified', '');
+      for (const file of diff.filesChanged) {
+        lines.push(`- \`${file}\``);
+      }
+      lines.push('');
+    }
+  } else {
+    lines.push('---', '', '## Changes', '', '_No file changes detected_', '');
+  }
+
+  return lines.join('\n');
+}
+
+function withToolHandler<TArgs>(handler: (services: Services, args: TArgs) => Promise<ResultEnvelope> | ResultEnvelope) {
+  return async (args: TArgs) => {
+    try {
+      const services = createServices();
+      const result = await handler(services, args);
+      return createTextResult(result, !result.success);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return createTextResult({ success: false, error: message }, true);
+    }
+  };
+}
+
+const server = new McpServer({
+  name: 'hive',
+  version: '1.4.3',
+});
+
+server.registerTool(
+  'feature_create',
+  {
+    description: 'Create a new Hive feature and make it active.',
+    inputSchema: z.object({
+      name: z.string().min(1).describe('Feature name'),
+      ticket: z.string().optional().describe('Optional ticket or issue reference'),
+    }),
+  },
+  withToolHandler(async ({ featureService }, args) => ({
+    success: true,
+    data: featureService.create(args.name, args.ticket),
+  })),
+);
+
+server.registerTool(
+  'feature_complete',
+  {
+    description: 'Mark a Hive feature as completed.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    return {
+      success: true,
+      data: services.featureService.complete(featureName),
+    };
+  }),
+);
+
+server.registerTool(
+  'plan_write',
+  {
+    description: 'Write or rewrite the plan.md for a Hive feature.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      content: z.string().min(1).describe('Markdown content for plan.md'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    return {
+      success: true,
+      data: { path: services.planService.write(featureName, args.content) },
+    };
+  }),
+);
+
+server.registerTool(
+  'plan_read',
+  {
+    description: 'Read plan.md and review state for a Hive feature.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const plan = services.planService.read(featureName);
+    if (!plan) {
+      return {
+        success: false,
+        error: `No plan.md found for feature '${featureName}'`,
+      };
+    }
+
+    return {
+      success: true,
+      data: plan,
+    };
+  }),
+);
+
+server.registerTool(
+  'plan_approve',
+  {
+    description: 'Approve a Hive plan for execution.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    services.planService.approve(featureName);
+    return {
+      success: true,
+      data: { feature: featureName, approved: true },
+    };
+  }),
+);
+
+server.registerTool(
+  'tasks_sync',
+  {
+    description: 'Generate or refresh Hive tasks from plan.md.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      refreshPending: z.boolean().optional().describe('Refresh pending tasks from the current plan'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    if (!services.planService.isApproved(featureName)) {
+      return {
+        success: false,
+        error: `Feature '${featureName}' does not have an approved plan`,
+        hints: ['Approve the plan before syncing tasks.'],
+      };
+    }
+
+    return {
+      success: true,
+      data: services.taskService.sync(featureName, { refreshPending: args.refreshPending }),
+    };
+  }),
+);
+
+server.registerTool(
+  'task_create',
+  {
+    description: 'Create an append-only manual Hive task outside plan.md.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      name: z.string().min(1).describe('Task name'),
+      order: z.number().int().positive().optional().describe('Explicit task order, if needed'),
+      description: z.string().optional().describe('What the task should accomplish'),
+      goal: z.string().optional().describe('Why this task exists'),
+      acceptanceCriteria: z.array(z.string()).optional().describe('Observable completion criteria'),
+      references: z.array(z.string()).optional().describe('Relevant file paths or references'),
+      files: z.array(z.string()).optional().describe('Files likely to change'),
+      dependsOn: z.array(z.string()).optional().describe('Completed task folders this task depends on'),
+      reason: z.string().optional().describe('Why the task was created'),
+      source: z.enum(['review', 'operator', 'ad_hoc']).optional().describe('Origin of this manual task'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const folder = services.taskService.create(featureName, args.name, args.order, {
+      description: args.description,
+      goal: args.goal,
+      acceptanceCriteria: args.acceptanceCriteria,
+      references: args.references,
+      files: args.files,
+      dependsOn: args.dependsOn,
+      reason: args.reason,
+      source: args.source,
+    });
+
+    return {
+      success: true,
+      data: {
+        feature: featureName,
+        task: folder,
+      },
+    };
+  }),
+);
+
+server.registerTool(
+  'task_update',
+  {
+    description: 'Update a Hive task status or summary.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      task: z.string().min(1).describe('Task folder name'),
+      status: z.enum(['pending', 'in_progress', 'done', 'cancelled', 'blocked', 'failed', 'partial']).optional(),
+      summary: z.string().optional().describe('Short work summary'),
+      baseCommit: z.string().optional().describe('Optional base commit metadata'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    return {
+      success: true,
+      data: services.taskService.update(featureName, args.task, {
+        status: args.status,
+        summary: args.summary,
+        baseCommit: args.baseCommit,
+      }),
+    };
+  }),
+);
+
+server.registerTool(
+  'context_write',
+  {
+    description: 'Write a Hive context markdown file.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      name: z.string().min(1).describe('Context file name without .md'),
+      content: z.string().min(1).describe('Markdown content'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    return {
+      success: true,
+      data: { path: services.contextService.write(featureName, args.name, args.content) },
+    };
+  }),
+);
+
+server.registerTool(
+  'status',
+  {
+    description: 'Get summary status for the active or specified Hive feature.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const feature = services.featureService.get(featureName);
+    if (!feature) {
+      return {
+        success: false,
+        error: `Feature '${featureName}' not found`,
+      };
+    }
+
+    const taskGraph = buildTaskGraph(services, featureName);
+    const planApproved = services.planService.isApproved(featureName);
+
+    return {
+      success: true,
+      data: {
+        feature,
+        info: services.featureService.getInfo(featureName),
+        planApproved,
+        tasks: {
+          total: taskGraph.tasks.length,
+          pending: taskGraph.tasks.filter((task) => task.status === 'pending').length,
+          inProgress: taskGraph.tasks.filter((task) => task.status === 'in_progress').length,
+          done: taskGraph.tasks.filter((task) => task.status === 'done').length,
+          list: taskGraph.tasks,
+          runnable: taskGraph.runnable,
+          blockedBy: taskGraph.blocked,
+        },
+        contexts: services.contextService.list(featureName).map((context) => ({
+          name: context.name,
+          role: context.role,
+          updatedAt: context.updatedAt,
+        })),
+        nextAction: getNextAction(featureName, planApproved, taskGraph),
+      },
+    };
+  }),
+);
+
+server.registerTool(
+  'worktree_start',
+  {
+    description: 'Create or reuse a task worktree and mark the task as in progress.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      task: z.string().min(1).describe('Task folder name'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const task = services.taskService.get(featureName, args.task);
+    if (!task) {
+      return {
+        success: false,
+        error: `Task '${args.task}' not found`,
+      };
+    }
+
+    if (task.status === 'blocked') {
+      return {
+        success: false,
+        error: `Task '${args.task}' is blocked and must be resumed with worktree_create.`,
+      };
+    }
+
+    if (task.status === 'done' || task.status === 'cancelled') {
+      return {
+        success: false,
+        error: `Task '${args.task}' is ${task.status} and cannot be started.`,
+      };
+    }
+
+    const worktree = await services.worktreeService.create(featureName, args.task);
+    services.taskService.update(featureName, args.task, {
+      status: 'in_progress',
+      baseCommit: worktree.commit,
+    });
+
+    return {
+      success: true,
+      data: {
+        feature: featureName,
+        task: args.task,
+        worktree,
+        nextAction: `Work inside ${worktree.path}, then finalize with worktree_commit and merge when ready.`,
+      },
+    };
+  }),
+);
+
+server.registerTool(
+  'worktree_create',
+  {
+    description: 'Resume a blocked task in its existing worktree.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      task: z.string().min(1).describe('Task folder name'),
+      continueFrom: z.literal('blocked').describe('Resume a blocked task'),
+      decision: z.string().optional().describe('Decision used to unblock the task'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const task = services.taskService.get(featureName, args.task);
+    if (!task) {
+      return {
+        success: false,
+        error: `Task '${args.task}' not found`,
+      };
+    }
+
+    if (task.status !== 'blocked') {
+      return {
+        success: false,
+        error: `Task '${args.task}' is not blocked. Use worktree_start for normal execution.`,
+      };
+    }
+
+    const worktree = await services.worktreeService.get(featureName, args.task);
+    if (!worktree) {
+      return {
+        success: false,
+        error: `No existing worktree found for task '${args.task}'.`,
+        hints: ['Use worktree_discard to reset the task, then start it again with worktree_start.'],
+      };
+    }
+
+    services.taskService.update(featureName, args.task, {
+      status: 'in_progress',
+      summary: args.decision ? `Resumed after decision: ${args.decision}` : task.summary,
+    });
+
+    return {
+      success: true,
+      data: {
+        feature: featureName,
+        task: args.task,
+        worktree,
+        decision: args.decision,
+      },
+    };
+  }),
+);
+
+server.registerTool(
+  'worktree_commit',
+  {
+    description: 'Commit or report the outcome of task work in a Hive worktree.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      task: z.string().min(1).describe('Task folder name'),
+      summary: z.string().min(1).describe('Summary of the completed work'),
+      message: z.string().optional().describe('Optional git commit message'),
+      status: z.enum(['completed', 'blocked', 'failed', 'partial']).optional().describe('Task completion status'),
+      blocker: z.object({
+        reason: z.string(),
+        options: z.array(z.string()).optional(),
+        recommendation: z.string().optional(),
+        context: z.string().optional(),
+      }).optional().describe('Blocker details when the task cannot continue'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const task = services.taskService.get(featureName, args.task);
+    if (!task) {
+      return {
+        success: false,
+        error: `Task '${args.task}' not found`,
+      };
+    }
+
+    if (task.status !== 'in_progress' && task.status !== 'blocked') {
+      return {
+        success: false,
+        error: `Task '${args.task}' is ${task.status}. Only in-progress or blocked tasks can be committed.`,
+      };
+    }
+
+    const finalStatus = args.status ?? 'completed';
+    const existingStatus = services.taskService.getRawStatus(featureName, args.task);
+    const worktree = await services.worktreeService.get(featureName, args.task);
+
+    if (finalStatus === 'blocked') {
+      services.taskService.update(featureName, args.task, {
+        status: 'blocked',
+        summary: args.summary,
+      });
+
+      return {
+        success: true,
+        data: {
+          feature: featureName,
+          task: args.task,
+          status: 'blocked',
+          blocker: args.blocker,
+          worktree,
+        },
+      };
+    }
+
+    const commitMessage = args.message || `hive(${args.task}): ${args.summary.slice(0, 72)}`;
+    const commit = await services.worktreeService.commitChanges(featureName, args.task, commitMessage);
+
+    if (finalStatus === 'completed' && !commit.committed && commit.message !== 'No changes to commit') {
+      return {
+        success: false,
+        error: commit.message || 'Commit failed',
+      };
+    }
+
+    const diff = await services.worktreeService.getDiff(featureName, args.task, existingStatus?.baseCommit);
+    const report = buildTaskReport({
+      featureName,
+      task: args.task,
+      finalStatus: finalStatus === 'completed' ? 'done' : finalStatus,
+      summary: args.summary,
+      commitSha: commit.sha,
+      diff,
+    });
+    const reportPath = services.taskService.writeReport(featureName, args.task, report);
+
+    services.taskService.update(featureName, args.task, {
+      status: finalStatus === 'completed' ? 'done' : finalStatus,
+      summary: args.summary,
+    });
+
+    return {
+      success: true,
+      data: {
+        feature: featureName,
+        task: args.task,
+        status: finalStatus === 'completed' ? 'done' : finalStatus,
+        commit,
+        diff,
+        worktree,
+        reportPath,
+      },
+    };
+  }),
+);
+
+server.registerTool(
+  'worktree_discard',
+  {
+    description: 'Discard a task worktree and reset the task back to pending.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      task: z.string().min(1).describe('Task folder name'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const task = services.taskService.get(featureName, args.task);
+    if (!task) {
+      return {
+        success: false,
+        error: `Task '${args.task}' not found`,
+      };
+    }
+
+    const cleanup = await services.worktreeService.remove(featureName, args.task);
+    services.taskService.update(featureName, args.task, {
+      status: 'pending',
+      summary: 'Task reset to pending after discarding worktree state.',
+    });
+
+    return {
+      success: true,
+      data: {
+        feature: featureName,
+        task: args.task,
+        cleanup,
+      },
+    };
+  }),
+);
+
+server.registerTool(
+  'merge',
+  {
+    description: 'Merge a completed task branch into the current branch.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+      task: z.string().min(1).describe('Task folder name'),
+      strategy: z.enum(['merge', 'squash', 'rebase']).optional().describe('Merge strategy'),
+      message: z.string().optional().describe('Optional merge message for merge or squash'),
+      preserveConflicts: z.boolean().optional().describe('Keep conflicts in place instead of aborting'),
+      cleanup: z.enum(['none', 'worktree', 'worktree+branch']).optional().describe('Cleanup mode after a successful merge'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    const task = services.taskService.get(featureName, args.task);
+    if (!task) {
+      return {
+        success: false,
+        error: `Task '${args.task}' not found`,
+      };
+    }
+
+    if (task.status !== 'done') {
+      return {
+        success: false,
+        error: `Task '${args.task}' must be completed before merging.`,
+      };
+    }
+
+    const result = await services.worktreeService.merge(featureName, args.task, args.strategy, args.message, {
+      preserveConflicts: args.preserveConflicts,
+      cleanup: args.cleanup,
+    });
+
+    return {
+      success: result.success,
+      data: result,
+      ...(result.success ? {} : { error: result.error || 'Merge failed' }),
+    };
+  }),
+);
+
+server.registerTool(
+  'agents_md_init',
+  {
+    description: 'Initialize AGENTS.md draft content from the current repository.',
+    inputSchema: z.object({}),
+  },
+  withToolHandler(async ({ agentsMdService }) => ({
+    success: true,
+    data: await agentsMdService.init(),
+  })),
+);
+
+server.registerTool(
+  'agents_md_sync',
+  {
+    description: 'Generate AGENTS.md sync proposals from feature context.',
+    inputSchema: z.object({
+      feature: z.string().optional().describe('Feature name, defaults to the active feature'),
+    }),
+  },
+  withToolHandler(async (services, args) => {
+    const featureName = resolveFeatureName(services, args.feature);
+    return {
+      success: true,
+      data: await services.agentsMdService.sync(featureName),
+    };
+  }),
+);
+
+server.registerTool(
+  'agents_md_apply',
+  {
+    description: 'Write approved AGENTS.md content into the repository root.',
+    inputSchema: z.object({
+      content: z.string().min(1).describe('Approved AGENTS.md content'),
+    }),
+  },
+  withToolHandler(async ({ agentsMdService }, args) => ({
+    success: true,
+    data: agentsMdService.apply(args.content),
+  })),
+);
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('claude-hive MCP server running on stdio');
+}
+
+main().catch((error) => {
+  console.error('Fatal error in claude-hive MCP server:', error);
+  process.exit(1);
+});

--- a/packages/claude-hive/tsconfig.json
+++ b/packages/claude-hive/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "..",
+    "outDir": "dist",
+    "lib": ["ES2022"],
+    "sourceMap": false,
+    "strict": false,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "hive-core": ["../hive-core/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.js"]
+}


### PR DESCRIPTION
feat(claude-hive): add new plugin package for Claude with build and r…untime support

- Updated package.json to include claude-hive in the build script.
- Added README.md for claude-hive detailing its purpose and usage.
- Created package.json for claude-hive with necessary scripts and dependencies.
- Introduced various agent definitions (architect-planner, forager-worker, hive-master, hygienic-reviewer, scout-researcher) to facilitate planning and implementation workflows.
- Implemented start command for initiating the Hive plan-first workflow.
- Developed plan-first skill to enforce structured planning processes.
- Added build-plugin script to generate the plugin artifact for local development.
- Created core runtime server for handling MCP requests and managing task workflows.
- Configured TypeScript settings for claude-hive package.