### PR TITLE
Tuning/make worker respond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ npm-debug.log*
 .env.local
 .ignore
 tmp/
+.tmp/
 
 # Hive runtime data
 .hive/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,7 @@ The previous worker's progress is preserved. Include the user's decision in the 
 
 **After task() Returns:**
 - task() is BLOCKING — when it returns, the worker is DONE
+- The terminal tool artifact (`hive_worktree_commit`) is the authoritative worker completion signal — no conversational response from the worker is required or expected
 - Call `hive_status()` immediately to check the new task state and find next runnable tasks
 - No notifications or polling needed — the result is already available
 - Prefer structured worker-result envelopes over free-form completion interpretation when extending worker/orchestrator flows

--- a/packages/opencode-hive/src/agents/forager.ts
+++ b/packages/opencode-hive/src/agents/forager.ts
@@ -117,8 +117,8 @@ hive_worktree_commit({
 \`\`\`
 
 Then inspect the tool response fields:
-- If \`ok=true\` and \`terminal=true\`: stop and hand off to orchestrator
-- If \`ok=false\` or \`terminal=false\`: DO NOT STOP. Follow \`nextAction\`, remediate, and retry \`hive_worktree_commit\`
+- If \`terminal=true\` (regardless of \`ok\`): the tool artifact is the authoritative handoff — stop immediately, no conversational response needed
+- If \`terminal=false\` (or \`ok=false\` with non-terminal): DO NOT STOP. Follow \`nextAction\`, remediate, and retry \`hive_worktree_commit\`
 
 **Blocked (need user decision):**
 \`\`\`

--- a/packages/opencode-hive/src/agents/hive.ts
+++ b/packages/opencode-hive/src/agents/hive.ts
@@ -214,8 +214,9 @@ hive_worktree_start({ task: "01-task-name" })  // Creates worktree + Forager
 5. If status is not \`blocked\`, do not use \`continueFrom: "blocked"\`; use \`hive_worktree_start({ feature, task })\` only for normal starts (\`pending\` / \`in_progress\`)
 6. Never loop \`continueFrom: "blocked"\` on non-blocked statuses
 7. If any Hive tool response has \`terminal: true\`, treat it as final for that call and do not retry the same parameters
-8. If task status is blocked: read blocker info → \`question()\` → user decision → resume with \`continueFrom: "blocked"\`
-9. Skip polling — the result is available when \`task()\` returns
+8. The terminal tool artifact (\`hive_worktree_commit\`) is the authoritative worker completion signal — no conversational response from the worker is required or expected
+9. If task status is blocked: read blocker info → \`question()\` → user decision → resume with \`continueFrom: "blocked"\`
+10. Skip polling — the result is available when \`task()\` returns
 
 ### Batch Merge + Verify Workflow
 When multiple tasks are in flight, prefer **batch completion** over per-task verification:

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -162,6 +162,11 @@ describe('Hive (Hybrid) prompt', () => {
       expect(QUEEN_BEE_PROMPT).toContain('do not retry the same parameters');
     });
 
+    it('treats terminal worker result as authoritative completion signal, no extra prose expected', () => {
+      expect(QUEEN_BEE_PROMPT).toContain('terminal tool artifact');
+      expect(QUEEN_BEE_PROMPT).toContain('no conversational response');
+    });
+
     it('redirects non-blocked unresolved tasks to normal dispatch', () => {
       expect(QUEEN_BEE_PROMPT).toContain('If status is not `blocked`');
       expect(QUEEN_BEE_PROMPT).toContain('do not use `continueFrom: "blocked"`');
@@ -347,6 +352,11 @@ describe('Swarm (Orchestrator) prompt', () => {
       expect(SWARM_BEE_PROMPT).toContain('hive_worktree_start({ feature, task })');
     });
 
+    it('treats terminal worker result as authoritative completion signal, no extra prose expected', () => {
+      expect(SWARM_BEE_PROMPT).toContain('terminal tool artifact');
+      expect(SWARM_BEE_PROMPT).toContain('no conversational response');
+    });
+
     it('includes task() guidance for research fan-out', () => {
       expect(SWARM_BEE_PROMPT).toContain('task() for research fan-out');
     });
@@ -425,6 +435,16 @@ describe('Forager (Worker/Coder) prompt', () => {
     expect(FORAGER_BEE_PROMPT).toContain('ok');
     expect(FORAGER_BEE_PROMPT).toContain('terminal');
     expect(FORAGER_BEE_PROMPT).toContain('DO NOT STOP');
+  });
+
+  it('stops on terminal=true regardless of ok value', () => {
+    expect(FORAGER_BEE_PROMPT).not.toContain('ok=true` and `terminal=true`');
+    expect(FORAGER_BEE_PROMPT).toContain('terminal=true` (regardless of `ok`)');
+  });
+
+  it('states terminal tool artifact is the authoritative handoff, no prose needed', () => {
+    expect(FORAGER_BEE_PROMPT).toContain('authoritative handoff');
+    expect(FORAGER_BEE_PROMPT).toContain('no conversational response');
   });
 
   it('adds resolve-before-blocking guidance', () => {

--- a/packages/opencode-hive/src/agents/swarm.ts
+++ b/packages/opencode-hive/src/agents/swarm.ts
@@ -84,6 +84,7 @@ Delegation guidance:
 - If status is not \`blocked\`, do not use \`continueFrom: "blocked"\`; use \`hive_worktree_start({ feature, task })\` only for normal starts (\`pending\` / \`in_progress\`)
 - Never loop \`continueFrom: "blocked"\` on non-blocked statuses
 - If any Hive tool response has \`terminal: true\`, treat it as final for that call and do not retry the same parameters
+- The terminal tool artifact (\`hive_worktree_commit\`) is the authoritative worker completion signal — no conversational response from the worker is required or expected
 - For parallel fan-out, issue multiple \`task()\` calls in the same message
 
 ## After Delegation - VERIFY

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -3185,9 +3185,7 @@ Original plan task four content must stay isolated from any append-only manual f
     expect(result.source).toBe('hive_worktree_commit');
     expect(typeof result.dedupeKey).toBe('string');
     expect((result.dedupeKey as string).length).toBeGreaterThan(0);
-    const parts = (result.dedupeKey as string).split(':');
-    expect(parts[0]).toBe('sess_worker_terminal_handoff_completed');
-    expect(parts[parts.length - 1]).toBe('completed');
+    expect(result.dedupeKey).toBe(`sess_worker_terminal_handoff_completed:msg_test:${FIRST_TASK}:completed`);
   });
 
   it('hive_worktree_commit blocked terminal response includes worker_terminal_handoff artifact type and dedupeKey', async () => {
@@ -3217,9 +3215,7 @@ Original plan task four content must stay isolated from any append-only manual f
     expect(result.type).toBe('worker_terminal_handoff');
     expect(result.source).toBe('hive_worktree_commit');
     expect(typeof result.dedupeKey).toBe('string');
-    const parts = (result.dedupeKey as string).split(':');
-    expect(parts[0]).toBe('sess_worker_terminal_handoff_blocked');
-    expect(parts[parts.length - 1]).toBe('blocked');
+    expect(result.dedupeKey).toBe(`sess_worker_terminal_handoff_blocked:msg_test:${FIRST_TASK}:blocked`);
   });
 
   it('hive_worktree_commit terminal response omits worker_terminal_handoff fields when synthesis disabled', async () => {
@@ -3317,8 +3313,6 @@ Original plan task four content must stay isolated from any append-only manual f
     expect(result.source).toBe('hive_worktree_commit');
     expect(typeof result.dedupeKey).toBe('string');
     expect((result.dedupeKey as string).length).toBeGreaterThan(0);
-    const parts = (result.dedupeKey as string).split(':');
-    expect(parts[0]).toBe('sess_worker_terminal_handoff_partial');
-    expect(parts[parts.length - 1]).toBe('partial');
+    expect(result.dedupeKey).toBe(`sess_worker_terminal_handoff_partial:msg_test:${FIRST_TASK}:partial`);
   });
 });

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -3143,4 +3143,106 @@ Original plan task four content must stay isolated from any append-only manual f
       'tool.execute.before',
     ]);
   });
+
+  it('hive_worktree_commit completed terminal response includes worker_terminal_handoff artifact type and dedupeKey', async () => {
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      'sess_terminal_handoff_completed',
+      'terminal-handoff-feature',
+      'Terminal Handoff Feature',
+      'Yes, this regression test validates that completed terminal commits include worker_terminal_handoff artifact fields.',
+    );
+
+    const workerContext = createToolContext('sess_worker_terminal_handoff_completed');
+    const raw = await hooks.tool!.hive_worktree_commit.execute(
+      {
+        task: FIRST_TASK,
+        summary: 'Completed task. Tests pass.',
+        status: 'completed',
+        feature: 'terminal-handoff-feature',
+      },
+      workerContext,
+    );
+
+    const result = JSON.parse(raw as string) as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    expect(result.terminal).toBe(true);
+    expect(result.type).toBe('worker_terminal_handoff');
+    expect(result.source).toBe('hive_worktree_commit');
+    expect(typeof result.dedupeKey).toBe('string');
+    expect((result.dedupeKey as string).length).toBeGreaterThan(0);
+    const parts = (result.dedupeKey as string).split(':');
+    expect(parts[0]).toBe('sess_worker_terminal_handoff_completed');
+    expect(parts[parts.length - 1]).toBe('completed');
+  });
+
+  it('hive_worktree_commit blocked terminal response includes worker_terminal_handoff artifact type and dedupeKey', async () => {
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      'sess_terminal_handoff_blocked',
+      'terminal-handoff-blocked-feature',
+      'Terminal Handoff Blocked Feature',
+      'Yes, this regression test validates that blocked terminal commits include worker_terminal_handoff artifact fields.',
+    );
+
+    const workerContext = createToolContext('sess_worker_terminal_handoff_blocked');
+    const raw = await hooks.tool!.hive_worktree_commit.execute(
+      {
+        task: FIRST_TASK,
+        summary: 'Blocked waiting for decision.',
+        status: 'blocked',
+        feature: 'terminal-handoff-blocked-feature',
+        blocker: { reason: 'Need a design decision' },
+      },
+      workerContext,
+    );
+
+    const result = JSON.parse(raw as string) as Record<string, unknown>;
+    expect(result.ok).toBe(true);
+    expect(result.terminal).toBe(true);
+    expect(result.type).toBe('worker_terminal_handoff');
+    expect(result.source).toBe('hive_worktree_commit');
+    expect(typeof result.dedupeKey).toBe('string');
+    const parts = (result.dedupeKey as string).split(':');
+    expect(parts[0]).toBe('sess_worker_terminal_handoff_blocked');
+    expect(parts[parts.length - 1]).toBe('blocked');
+  });
+
+  it('hive_worktree_commit terminal response omits worker_terminal_handoff fields when synthesis disabled', async () => {
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      'sess_terminal_handoff_disabled',
+      'terminal-handoff-disabled-feature',
+      'Terminal Handoff Disabled Feature',
+      'Yes, this regression test validates that synthesis can be disabled via control point.',
+    );
+
+    const prev = process.env.ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS;
+    process.env.ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS = 'false';
+    try {
+      const workerContext = createToolContext('sess_worker_terminal_handoff_disabled');
+      const raw = await hooks.tool!.hive_worktree_commit.execute(
+        {
+          task: FIRST_TASK,
+          summary: 'Completed. Tests pass.',
+          status: 'completed',
+          feature: 'terminal-handoff-disabled-feature',
+        },
+        workerContext,
+      );
+
+      const result = JSON.parse(raw as string) as Record<string, unknown>;
+      expect(result.ok).toBe(true);
+      expect(result.terminal).toBe(true);
+      expect(result.type).toBeUndefined();
+      expect(result.source).toBeUndefined();
+      expect(result.dedupeKey).toBeUndefined();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS;
+      } else {
+        process.env.ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS = prev;
+      }
+    }
+  });
 });

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -1876,6 +1876,9 @@ Do it
       taskState?: string;
       verificationNote?: string;
       nextAction?: string;
+      type?: string;
+      source?: string;
+      dedupeKey?: string;
     };
 
     expect(commitResult.ok).toBe(true);
@@ -1884,6 +1887,10 @@ Do it
     expect(commitResult.taskState).toBe("done");
     expect(commitResult.verificationNote).toContain("No verification evidence in summary");
     expect(commitResult.nextAction).toContain("hive_merge");
+    expect(commitResult.type).toBe("worker_terminal_handoff");
+    expect(commitResult.source).toBe("hive_worktree_commit");
+    expect(typeof commitResult.dedupeKey).toBe("string");
+    expect((commitResult.dedupeKey as string).split(":").at(-1)).toBe("completed");
   });
 
   it("returns terminal JSON response when commit completes", async () => {
@@ -1959,6 +1966,9 @@ Do it
       taskState?: string;
       commit?: { sha?: string };
       nextAction?: string;
+      type?: string;
+      source?: string;
+      dedupeKey?: string;
     };
 
     expect(commitResult.ok).toBe(true);
@@ -1967,6 +1977,10 @@ Do it
     expect(commitResult.taskState).toBe("done");
     expect(commitResult.commit?.sha).toBeDefined();
     expect(commitResult.nextAction).toContain("hive_merge");
+    expect(commitResult.type).toBe("worker_terminal_handoff");
+    expect(commitResult.source).toBe("hive_worktree_commit");
+    expect(typeof commitResult.dedupeKey).toBe("string");
+    expect((commitResult.dedupeKey as string).split(":").at(-1)).toBe("completed");
   });
 
   it("uses custom commit message in task worktree head", async () => {
@@ -3244,5 +3258,67 @@ Original plan task four content must stay isolated from any append-only manual f
         process.env.ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS = prev;
       }
     }
+  });
+
+  it('hive_worktree_commit failed terminal response includes worker_terminal_handoff artifact type and dedupeKey', async () => {
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      'sess_terminal_handoff_failed',
+      'terminal-handoff-failed-feature',
+      'Terminal Handoff Failed Feature',
+      'Yes, this regression test validates that failed terminal commits include worker_terminal_handoff artifact fields.',
+    );
+
+    const workerContext = createToolContext('sess_worker_terminal_handoff_failed');
+    const raw = await hooks.tool!.hive_worktree_commit.execute(
+      {
+        task: FIRST_TASK,
+        summary: 'Encountered unrecoverable error during implementation.',
+        status: 'failed',
+        feature: 'terminal-handoff-failed-feature',
+      },
+      workerContext,
+    );
+
+    const result = JSON.parse(raw as string) as Record<string, unknown>;
+    expect(result.terminal).toBe(true);
+    expect(result.type).toBe('worker_terminal_handoff');
+    expect(result.source).toBe('hive_worktree_commit');
+    expect(typeof result.dedupeKey).toBe('string');
+    expect((result.dedupeKey as string).length).toBeGreaterThan(0);
+    const parts = (result.dedupeKey as string).split(':');
+    expect(parts[0]).toBe('sess_worker_terminal_handoff_failed');
+    expect(parts[parts.length - 1]).toBe('failed');
+  });
+
+  it('hive_worktree_commit partial terminal response includes worker_terminal_handoff artifact type and dedupeKey', async () => {
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      'sess_terminal_handoff_partial',
+      'terminal-handoff-partial-feature',
+      'Terminal Handoff Partial Feature',
+      'Yes, this regression test validates that partial terminal commits include worker_terminal_handoff artifact fields.',
+    );
+
+    const workerContext = createToolContext('sess_worker_terminal_handoff_partial');
+    const raw = await hooks.tool!.hive_worktree_commit.execute(
+      {
+        task: FIRST_TASK,
+        summary: 'Completed steps 1-2. Step 3 remains due to time constraints.',
+        status: 'partial',
+        feature: 'terminal-handoff-partial-feature',
+      },
+      workerContext,
+    );
+
+    const result = JSON.parse(raw as string) as Record<string, unknown>;
+    expect(result.terminal).toBe(true);
+    expect(result.type).toBe('worker_terminal_handoff');
+    expect(result.source).toBe('hive_worktree_commit');
+    expect(typeof result.dedupeKey).toBe('string');
+    expect((result.dedupeKey as string).length).toBeGreaterThan(0);
+    const parts = (result.dedupeKey as string).split(':');
+    expect(parts[0]).toBe('sess_worker_terminal_handoff_partial');
+    expect(parts[parts.length - 1]).toBe('partial');
   });
 });

--- a/packages/opencode-hive/src/index.ts
+++ b/packages/opencode-hive/src/index.ts
@@ -206,6 +206,28 @@ import { HIVE_SYSTEM_PROMPT, shouldExecuteHook } from "./hooks/system-hook.js";
 import { HIVE_COMMANDS, HIVE_TOOL_NAMES } from './utils/plugin-manifest.js';
 
 /**
+ * Runtime rollback control point. Set ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS=false
+ * to disable deterministic closure artifact emission and fall back to legacy behavior.
+ * Default: true (synthesis enabled).
+ */
+function isTerminalHandoffSynthesisEnabled(): boolean {
+  return process.env.ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS !== 'false';
+}
+
+function buildTerminalHandoffArtifact(
+  toolContext: { sessionID: string; messageID: string },
+  task: string,
+  status: string,
+): Record<string, string> {
+  const dedupeKey = `${toolContext.sessionID}:${toolContext.messageID}:${task}:${status}`;
+  return {
+    type: 'worker_terminal_handoff',
+    source: 'hive_worktree_commit',
+    dedupeKey,
+  };
+}
+
+/**
  * Core plugin implementation.
  */
 type ToolContext = {
@@ -1494,6 +1516,7 @@ Expand your Discovery section and try again.`;
               branch: worktree?.branch,
               message: 'Task blocked. Hive Master will ask user and resume with hive_worktree_create(continueFrom: "blocked", decision: answer)',
               nextAction: 'Wait for orchestrator to collect user decision and resume with continueFrom: "blocked".',
+              ...(isTerminalHandoffSynthesisEnabled() && buildTerminalHandoffArtifact(toolContext as ToolContext, task, 'blocked')),
             });
           }
 
@@ -1588,6 +1611,7 @@ Expand your Discovery section and try again.`;
             reportPath,
             message: `Task "${task}" ${status}.`,
             nextAction: 'Use hive_merge to integrate changes. Worktree is preserved for review.',
+            ...(isTerminalHandoffSynthesisEnabled() && buildTerminalHandoffArtifact(toolContext as ToolContext, task, status)),
           });
         },
       }),

--- a/packages/opencode-hive/src/utils/worker-prompt.test.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.test.ts
@@ -164,6 +164,21 @@ UNIQUE_MARKER_12345
     expect(prompt).toContain('result.nextAction');
   });
 
+  it('states terminal tool artifact is the authoritative completion handoff', () => {
+    const params = createTestParams();
+    const prompt = buildWorkerPrompt(params);
+
+    expect(prompt).toContain('terminal tool artifact');
+    expect(prompt).toContain('authoritative');
+  });
+
+  it('does not require conversational prose after terminal commit', () => {
+    const params = createTestParams();
+    const prompt = buildWorkerPrompt(params);
+
+    expect(prompt).toContain('no conversational response');
+  });
+
   it('keeps ordinary workers merge-forbidden and delegation-forbidden', () => {
     const params = createTestParams();
     const prompt = buildWorkerPrompt(params);

--- a/packages/opencode-hive/src/utils/worker-prompt.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.ts
@@ -209,7 +209,8 @@ If commit returns non-terminal (for example verification_required), DO NOT STOP.
 Follow result.nextAction, fix the issue, and call hive_worktree_commit again.
 
 Only when commit result is terminal should you stop.
-Do NOT continue working after a terminal result. Do NOT respond further. Your session is DONE.
+The terminal tool artifact is the authoritative completion handoff — no conversational response is required or expected.
+Do NOT continue working after a terminal result. Your session is DONE.
 The Hive Master will take over from here.
 
 **Summary Guidance** (used verbatim for downstream task context):


### PR DESCRIPTION
## Summary

This PR fixes the worker completion path so terminal `hive_worktree_commit` results are treated as the authoritative handoff, instead of depending on an extra assistant turn to make completion visible.

The main problem was a mismatch between prompt/runtime expectations and what actually happens when a worker finishes. A worker could do the right thing, return a terminal tool result, and still look like it ended silently.

This change makes that flow deterministic.

## What Changed

### Runtime / tool contract

- terminal `hive_worktree_commit` responses now carry explicit handoff fields:
  - `type: worker_terminal_handoff`
  - `source: hive_worktree_commit`
  - `dedupeKey`
- terminal statuses (`completed`, `blocked`, `failed`, `partial`) are handled consistently
- added a rollback control point: `ENABLE_WORKER_TERMINAL_HANDOFF_SYNTHESIS=false`

### Prompt / agent alignment

- updated worker prompt guidance to treat terminal tool artifacts as the completion handoff
- kept retry/remediation behavior for non-terminal responses intact
- aligned Forager, Hive, and Swarm prompts with the same contract
- removed any implied requirement for extra post-commit prose

### Test coverage

- added runtime regression coverage for:
  - terminal handoff without an extra model turn
  - no false closure when no terminal artifact exists
  - single-emission behavior
  - synthesis-disabled rollback path
- added agent-hive e2e coverage for completed / blocked / failed / partial terminal visibility
- tightened the local `dedupeKey` assertions so the tool-layer contract is explicit and test-locked

## Notes

- Runtime ownership of the single-emission / no-false-positive behavior remains upstream in the opencode runtime suite.

## Validation

- `bun run build` ✅
- `bun run test` ✅

Breakdown from the final verification run:
- `hive-core`: 237 pass, 0 fail
- `opencode-hive`: 468 pass, 0 fail
- `vscode-hive`: 73 pass, 0 fail
