### PR TITLE
Tuning: Response-First Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ npm-debug.log*
 .env.local
 .ignore
 tmp/
+.tmp/
 
 # Hive runtime data
 .hive/

--- a/packages/opencode-hive/src/agents/forager.ts
+++ b/packages/opencode-hive/src/agents/forager.ts
@@ -117,8 +117,10 @@ hive_worktree_commit({
 \`\`\`
 
 Then inspect the tool response fields:
-- If \`ok=true\` and \`terminal=true\`: stop and hand off to orchestrator
+- If \`terminal=true\` (regardless of \`ok\`): send one final concise handoff response to the orchestrator, then stop
 - If \`ok=false\` or \`terminal=false\`: DO NOT STOP. Follow \`nextAction\`, remediate, and retry \`hive_worktree_commit\`
+
+Use the handoff response to summarize what changed, why (if relevant), and verification evidence (or "Not run" with reason).
 
 **Blocked (need user decision):**
 \`\`\`

--- a/packages/opencode-hive/src/agents/hive.ts
+++ b/packages/opencode-hive/src/agents/hive.ts
@@ -214,6 +214,7 @@ hive_worktree_start({ task: "01-task-name" })  // Creates worktree + Forager
 5. If status is not \`blocked\`, do not use \`continueFrom: "blocked"\`; use \`hive_worktree_start({ feature, task })\` only for normal starts (\`pending\` / \`in_progress\`)
 6. Never loop \`continueFrom: "blocked"\` on non-blocked statuses
 7. If any Hive tool response has \`terminal: true\`, treat it as final for that call and do not retry the same parameters
+   - This finality applies to the tool call parameters and does not prohibit the worker’s final natural-language handoff response
 8. If task status is blocked: read blocker info → \`question()\` → user decision → resume with \`continueFrom: "blocked"\`
 9. Skip polling — the result is available when \`task()\` returns
 

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -146,6 +146,7 @@ describe('Hive (Hybrid) prompt', () => {
 
     it('allows blocked resume only for exactly blocked tasks', () => {
       expect(QUEEN_BEE_PROMPT).toContain('Use `continueFrom: "blocked"` only when status is exactly `blocked`');
+      expect(QUEEN_BEE_PROMPT).not.toContain('Use `continueFrom: "blocked"` when status is unresolved');
     });
 
     it('forbids blocked resume loops on non-blocked statuses', () => {
@@ -160,6 +161,7 @@ describe('Hive (Hybrid) prompt', () => {
     it('treats terminal tool responses as non-retriable for same parameters', () => {
       expect(QUEEN_BEE_PROMPT).toContain('If any Hive tool response has `terminal: true`');
       expect(QUEEN_BEE_PROMPT).toContain('do not retry the same parameters');
+      expect(QUEEN_BEE_PROMPT).toContain('finality applies to the tool call parameters');
       expect(QUEEN_BEE_PROMPT).toContain('tool call parameters');
       expect(QUEEN_BEE_PROMPT).toContain('final natural-language handoff response');
     });
@@ -338,6 +340,11 @@ describe('Swarm (Orchestrator) prompt', () => {
       expect(SWARM_BEE_PROMPT).toContain('Use `continueFrom: "blocked"` only when status is exactly `blocked`');
     });
 
+    it('requires immediate status re-check before each blocked resume', () => {
+      expect(SWARM_BEE_PROMPT).toContain('Before every blocked resume, call `hive_status()` immediately beforehand');
+      expect(SWARM_BEE_PROMPT).toContain('verify the task is still exactly `blocked`');
+    });
+
     it('forbids blocked resume loops on non-blocked statuses', () => {
       expect(SWARM_BEE_PROMPT).toContain('Never loop `continueFrom: "blocked"` on non-blocked statuses');
     });
@@ -438,9 +445,12 @@ describe('Forager (Worker/Coder) prompt', () => {
 
   it('requires a final concise handoff response after terminal commit', () => {
     expect(FORAGER_BEE_PROMPT).toContain('send one final concise handoff response');
+    expect(FORAGER_BEE_PROMPT).toContain('to the orchestrator');
     expect(FORAGER_BEE_PROMPT).toContain('what changed');
+    expect(FORAGER_BEE_PROMPT).toContain('why (if relevant)');
     expect(FORAGER_BEE_PROMPT).toContain('verification evidence');
     expect(FORAGER_BEE_PROMPT).not.toContain('stop and hand off to orchestrator');
+    expect(FORAGER_BEE_PROMPT).not.toContain('Do NOT respond further');
   });
 
   it('adds resolve-before-blocking guidance', () => {

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -422,9 +422,16 @@ describe('Forager (Worker/Coder) prompt', () => {
   });
 
   it('requires terminal commit result before stopping', () => {
-    expect(FORAGER_BEE_PROMPT).toContain('ok');
+    expect(FORAGER_BEE_PROMPT).toContain('regardless of `ok`');
     expect(FORAGER_BEE_PROMPT).toContain('terminal');
     expect(FORAGER_BEE_PROMPT).toContain('DO NOT STOP');
+  });
+
+  it('requires a final concise handoff response after terminal commit', () => {
+    expect(FORAGER_BEE_PROMPT).toContain('send one final concise handoff response');
+    expect(FORAGER_BEE_PROMPT).toContain('what changed');
+    expect(FORAGER_BEE_PROMPT).toContain('verification evidence');
+    expect(FORAGER_BEE_PROMPT).not.toContain('stop and hand off to orchestrator');
   });
 
   it('adds resolve-before-blocking guidance', () => {

--- a/packages/opencode-hive/src/agents/prompts.test.ts
+++ b/packages/opencode-hive/src/agents/prompts.test.ts
@@ -160,6 +160,8 @@ describe('Hive (Hybrid) prompt', () => {
     it('treats terminal tool responses as non-retriable for same parameters', () => {
       expect(QUEEN_BEE_PROMPT).toContain('If any Hive tool response has `terminal: true`');
       expect(QUEEN_BEE_PROMPT).toContain('do not retry the same parameters');
+      expect(QUEEN_BEE_PROMPT).toContain('tool call parameters');
+      expect(QUEEN_BEE_PROMPT).toContain('final natural-language handoff response');
     });
 
     it('redirects non-blocked unresolved tasks to normal dispatch', () => {
@@ -338,6 +340,13 @@ describe('Swarm (Orchestrator) prompt', () => {
 
     it('forbids blocked resume loops on non-blocked statuses', () => {
       expect(SWARM_BEE_PROMPT).toContain('Never loop `continueFrom: "blocked"` on non-blocked statuses');
+    });
+
+    it('clarifies terminal finality scope while allowing final natural-language handoff', () => {
+      expect(SWARM_BEE_PROMPT).toContain('If any Hive tool response has `terminal: true`');
+      expect(SWARM_BEE_PROMPT).toContain('do not retry the same parameters');
+      expect(SWARM_BEE_PROMPT).toContain('tool call parameters');
+      expect(SWARM_BEE_PROMPT).toContain('final natural-language handoff response');
     });
 
     it('redirects non-blocked unresolved tasks to normal dispatch', () => {

--- a/packages/opencode-hive/src/agents/swarm.ts
+++ b/packages/opencode-hive/src/agents/swarm.ts
@@ -84,6 +84,7 @@ Delegation guidance:
 - If status is not \`blocked\`, do not use \`continueFrom: "blocked"\`; use \`hive_worktree_start({ feature, task })\` only for normal starts (\`pending\` / \`in_progress\`)
 - Never loop \`continueFrom: "blocked"\` on non-blocked statuses
 - If any Hive tool response has \`terminal: true\`, treat it as final for that call and do not retry the same parameters
+- This finality applies to the tool call parameters and does not prohibit the worker’s final natural-language handoff response
 - For parallel fan-out, issue multiple \`task()\` calls in the same message
 
 ## After Delegation - VERIFY

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -1846,8 +1846,6 @@ Do it
     expect(commitResult.terminal).toBe(true);
     expect(commitResult.status).toBe("completed");
     expect(commitResult.taskState).toBe("done");
-    expect(commitResult.verificationNote).toBeUndefined();
-    expect(commitResult.commit?.sha).toBeDefined();
     expect(commitResult.nextAction).toContain("hive_merge");
   });
 
@@ -1884,7 +1882,6 @@ Do it
     expect(commitResult.terminal).toBe(true);
     expect(commitResult.status).toBe("completed");
     expect(commitResult.taskState).toBe("done");
-    expect(commitResult.verificationNote).toContain("No verification evidence in summary");
     expect(commitResult.nextAction).toContain("hive_merge");
 
     const statusRaw = await hooks.tool!.hive_status.execute(

--- a/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
+++ b/packages/opencode-hive/src/e2e/plugin-smoke.test.ts
@@ -1810,61 +1810,63 @@ Do it
     expect(result.worktreePath).toBeDefined();
   });
 
-  it("returns terminal JSON with advisory note when verification evidence is missing", async () => {
-    const ctx: PluginInput = {
-      directory: testRoot,
-      worktree: testRoot,
-      serverUrl: new URL("http://localhost:1"),
-      project: createProject(testRoot),
-      client: OPENCODE_CLIENT,
-      $: createStubShell(),
+  it("treats a single completed commit call as the expected terminal merge-ready path", async () => {
+    const feature = "commit-expected-path-feature";
+    const { hooks, toolContext, worktreePath } = await createSingleTaskWorktree(
+      testRoot,
+      "sess_commit_expected_path",
+      feature,
+      "Commit Expected Path Feature",
+      "Yes, this test validates that one completed commit call returns terminal merge-ready output.",
+    );
+
+    fs.writeFileSync(path.join(worktreePath, "task-note.txt"), "commit expected path test\n");
+
+    const commitRaw = await hooks.tool!.hive_worktree_commit.execute(
+      {
+        feature,
+        task: FIRST_TASK,
+        status: "completed",
+        summary: "Added expected-path note file. Tests pass (bun test). Build succeeds (bun run build).",
+      },
+      toolContext
+    );
+
+    const commitResult = JSON.parse(commitRaw as string) as {
+      ok: boolean;
+      terminal: boolean;
+      status: string;
+      taskState?: string;
+      verificationNote?: string;
+      commit?: { sha?: string };
+      nextAction?: string;
     };
 
-    const hooks = await plugin(ctx);
-    const toolContext = createToolContext("sess_commit_gate");
+    expect(commitResult.ok).toBe(true);
+    expect(commitResult.terminal).toBe(true);
+    expect(commitResult.status).toBe("completed");
+    expect(commitResult.taskState).toBe("done");
+    expect(commitResult.verificationNote).toBeUndefined();
+    expect(commitResult.commit?.sha).toBeDefined();
+    expect(commitResult.nextAction).toContain("hive_merge");
+  });
 
-    await hooks.tool!.hive_feature_create.execute(
-      { name: "commit-gate-feature" },
-      toolContext
-    );
-
-    const plan = `# Commit Gate Feature
-
-## Discovery
-
-**Q: Is this a test?**
-A: Yes, this test validates non-terminal completion responses when verification evidence is missing from summary.
-
-## Tasks
-
-### 1. First Task
-Do it
-`;
-
-    await hooks.tool!.hive_plan_write.execute(
-      { content: plan, feature: "commit-gate-feature" },
-      toolContext
-    );
-    await hooks.tool!.hive_plan_approve.execute(
-      { feature: "commit-gate-feature" },
-      toolContext
-    );
-    await hooks.tool!.hive_tasks_sync.execute(
-      { feature: "commit-gate-feature" },
-      toolContext
-    );
-
-    await hooks.tool!.hive_worktree_start.execute(
-      { feature: "commit-gate-feature", task: "01-first-task" },
-      toolContext
+  it("keeps advisory fallback completion terminal and done without requiring commit retry", async () => {
+    const feature = "commit-advisory-fallback-feature";
+    const { hooks, toolContext } = await createSingleTaskWorktree(
+      testRoot,
+      "sess_commit_advisory_fallback",
+      feature,
+      "Commit Advisory Fallback Feature",
+      "Yes, this test validates advisory fallback interpretation with minimal completion summary and no retry requirement.",
     );
 
     const commitRaw = await hooks.tool!.hive_worktree_commit.execute(
       {
-        feature: "commit-gate-feature",
-        task: "01-first-task",
+        feature,
+        task: FIRST_TASK,
         status: "completed",
-        summary: "Implemented feature changes.",
+        summary: "Completed.",
       },
       toolContext
     );
@@ -1884,89 +1886,19 @@ Do it
     expect(commitResult.taskState).toBe("done");
     expect(commitResult.verificationNote).toContain("No verification evidence in summary");
     expect(commitResult.nextAction).toContain("hive_merge");
-  });
 
-  it("returns terminal JSON response when commit completes", async () => {
-    const ctx: PluginInput = {
-      directory: testRoot,
-      worktree: testRoot,
-      serverUrl: new URL("http://localhost:1"),
-      project: createProject(testRoot),
-      client: OPENCODE_CLIENT,
-      $: createStubShell(),
+    const statusRaw = await hooks.tool!.hive_status.execute(
+      { feature },
+      toolContext
+    );
+    const status = JSON.parse(statusRaw as string) as {
+      tasks?: {
+        list?: Array<{ folder: string; status: string }>;
+      };
     };
 
-    const hooks = await plugin(ctx);
-    const toolContext = createToolContext("sess_commit_success");
-
-    await hooks.tool!.hive_feature_create.execute(
-      { name: "commit-success-feature" },
-      toolContext
-    );
-
-    const plan = `# Commit Success Feature
-
-## Discovery
-
-**Q: Is this a test?**
-A: Yes, this test validates terminal completion responses when commit succeeds.
-
-## Tasks
-
-### 1. First Task
-Do it
-`;
-
-    await hooks.tool!.hive_plan_write.execute(
-      { content: plan, feature: "commit-success-feature" },
-      toolContext
-    );
-    await hooks.tool!.hive_plan_approve.execute(
-      { feature: "commit-success-feature" },
-      toolContext
-    );
-    await hooks.tool!.hive_tasks_sync.execute(
-      { feature: "commit-success-feature" },
-      toolContext
-    );
-
-    const worktreeRaw = await hooks.tool!.hive_worktree_start.execute(
-      { feature: "commit-success-feature", task: "01-first-task" },
-      toolContext
-    );
-    const worktreeResult = JSON.parse(worktreeRaw as string) as {
-      worktreePath?: string;
-    };
-
-    expect(worktreeResult.worktreePath).toBeDefined();
-    const worktreePath = worktreeResult.worktreePath!;
-    fs.writeFileSync(path.join(worktreePath, "task-note.txt"), "commit test\n");
-
-    const commitRaw = await hooks.tool!.hive_worktree_commit.execute(
-      {
-        feature: "commit-success-feature",
-        task: "01-first-task",
-        status: "completed",
-        summary: "Added task note file. Tests pass (bun test). Build succeeds (bun run build).",
-      },
-      toolContext
-    );
-
-    const commitResult = JSON.parse(commitRaw as string) as {
-      ok: boolean;
-      terminal: boolean;
-      status: string;
-      taskState?: string;
-      commit?: { sha?: string };
-      nextAction?: string;
-    };
-
-    expect(commitResult.ok).toBe(true);
-    expect(commitResult.terminal).toBe(true);
-    expect(commitResult.status).toBe("completed");
-    expect(commitResult.taskState).toBe("done");
-    expect(commitResult.commit?.sha).toBeDefined();
-    expect(commitResult.nextAction).toContain("hive_merge");
+    const taskStatus = status.tasks?.list?.find((task) => task.folder === FIRST_TASK);
+    expect(taskStatus?.status).toBe("done");
   });
 
   it("uses custom commit message in task worktree head", async () => {

--- a/packages/opencode-hive/src/utils/worker-prompt.test.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.test.ts
@@ -163,6 +163,8 @@ UNIQUE_MARKER_12345
     expect(prompt).toContain('DO NOT STOP');
     expect(prompt).toContain('result.nextAction');
     expect(prompt).toContain('regardless of `ok`');
+    expect(prompt).toContain('must not be retried with the same parameters');
+    expect(prompt).not.toContain('stop immediately');
   });
 
   it('requires final concise handoff response after terminal commit', () => {

--- a/packages/opencode-hive/src/utils/worker-prompt.test.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.test.ts
@@ -155,16 +155,16 @@ UNIQUE_MARKER_12345
     expect(prompt).toContain('hive_worktree_commit');
   });
 
-  it('requires terminal commit result before stopping', () => {
+  it('requires terminal commit result before stopping and preserves retry flow for non-terminal results', () => {
     const params = createTestParams();
     const prompt = buildWorkerPrompt(params);
 
     expect(prompt).toContain('terminal=true');
+    expect(prompt).toContain('this call is final');
     expect(prompt).toContain('DO NOT STOP');
     expect(prompt).toContain('result.nextAction');
     expect(prompt).toContain('regardless of `ok`');
     expect(prompt).toContain('must not be retried with the same parameters');
-    expect(prompt).not.toContain('stop immediately');
   });
 
   it('requires final concise handoff response after terminal commit', () => {
@@ -172,10 +172,18 @@ UNIQUE_MARKER_12345
     const prompt = buildWorkerPrompt(params);
 
     expect(prompt).toContain('send one final concise handoff response');
+    expect(prompt).toContain('to the orchestrator');
     expect(prompt).toContain('what changed');
     expect(prompt).toContain('why');
     expect(prompt).toContain('verification evidence');
+  });
+
+  it('omits contradictory no-response wording after terminal commit', () => {
+    const params = createTestParams();
+    const prompt = buildWorkerPrompt(params);
+
     expect(prompt).not.toContain('Do NOT respond further');
+    expect(prompt).not.toContain('no conversational response is required or expected');
   });
 
   it('keeps ordinary workers merge-forbidden and delegation-forbidden', () => {

--- a/packages/opencode-hive/src/utils/worker-prompt.test.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.test.ts
@@ -162,6 +162,18 @@ UNIQUE_MARKER_12345
     expect(prompt).toContain('terminal=true');
     expect(prompt).toContain('DO NOT STOP');
     expect(prompt).toContain('result.nextAction');
+    expect(prompt).toContain('regardless of `ok`');
+  });
+
+  it('requires final concise handoff response after terminal commit', () => {
+    const params = createTestParams();
+    const prompt = buildWorkerPrompt(params);
+
+    expect(prompt).toContain('send one final concise handoff response');
+    expect(prompt).toContain('what changed');
+    expect(prompt).toContain('why');
+    expect(prompt).toContain('verification evidence');
+    expect(prompt).not.toContain('Do NOT respond further');
   });
 
   it('keeps ordinary workers merge-forbidden and delegation-forbidden', () => {

--- a/packages/opencode-hive/src/utils/worker-prompt.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.ts
@@ -209,7 +209,9 @@ If commit returns non-terminal (for example verification_required), DO NOT STOP.
 Follow result.nextAction, fix the issue, and call hive_worktree_commit again.
 
 Only when commit result is terminal should you stop.
-Do NOT continue working after a terminal result. Do NOT respond further. Your session is DONE.
+After a terminal result, send one final concise handoff response to the orchestrator, then stop.
+The final response should include what changed, why (if relevant), and verification evidence (or "Not run" with reason).
+Do NOT continue working after that final response. Your session is DONE.
 The Hive Master will take over from here.
 
 **Summary Guidance** (used verbatim for downstream task context):

--- a/packages/opencode-hive/src/utils/worker-prompt.ts
+++ b/packages/opencode-hive/src/utils/worker-prompt.ts
@@ -201,7 +201,7 @@ hive_worktree_commit({
 - Do not provide message with hive_merge(..., strategy: 'rebase').
 
 Then inspect the tool response fields:
-- If \`terminal=true\` (regardless of \`ok\`): stop immediately. This call is final and must not be retried with the same parameters.
+- If \`terminal=true\` (regardless of \`ok\`): this call is final and must not be retried with the same parameters. Send one final concise handoff response to the orchestrator, then stop.
 - If \`terminal=false\`: **DO NOT STOP**. Follow \`nextAction\`, remediate, and retry \`hive_worktree_commit\`
 
 **CRITICAL: Any terminal commit result is final for this call.**


### PR DESCRIPTION
## Summary

This PR makes worker completion response-first at the prompt contract layer.

After a worker gets a terminal `hive_worktree_commit` result, it should still send one short natural-language handoff before the session ends. The main problem before this was prompt drift: parts of the system treated terminal tool output as final, but some wording still implied the worker should effectively go silent.

This change resolves that contradiction without changing the runtime tool contract in `packages/opencode-hive/src/index.ts`.

## The problem

The prompt contract was split. Terminal commit results were already treated as final by the tool layer, but the worker-facing wording still suggested silence after completion. That left a gap between what the system did and what the worker was told to do, which is exactly the kind of drift that makes completions feel flaky. Orchestrators often overreacted resulting in unnecessary work which would've not happened if the worker has just responded the work went well..

## How This Solves It

The prompts now say the same thing everywhere: terminal commit results are final for retry purposes, and the worker still sends one concise handoff before stopping. The tests lock that in, so the wording can change later without reintroducing the old silent-completion behavior. The runtime contract stays untouched.

## What Changed

### Prompt / agent alignment

- updated worker and Forager prompt wording to require one final concise handoff after terminal commit
- updated Hive and Swarm wording to clarify that terminal finality applies to the tool-call parameters, not to suppressing the worker's final response
- kept blocked-resume and same-parameter non-retry behavior intact

## Validation

All tests still pass.

## Manual Smoke Test

Example:

> Create a tiny throwaway task in a worktree that makes one harmless change, like adjusting a temporary test string or adding a one-line comment in a disposable spot, then complete it normally and report back.

What you want to see:

- the worker reaches a terminal `hive_worktree_commit` result
- the task completes without retrying the same commit call
- after that terminal result, the worker still sends one short natural-language handoff summarizing what changed and what it verified
- it should happen because of the prompt contract, not because we explicitly asked for that response

```
⚙ hive_worktree_start [task=04-create-throwaway-harmless-change]
I’ve created the isolated worktree and the task is runnable. Because this is a tiny, well-defined change, I’m delegating it to a simple forager worker using the provided worker prompt verbatim.
│ Forager-Simple Task — Hive: 04-create-throwaway-harmless-change
└ 8 toolcalls · 56.3s
ctrl+x down view subagents
The worker reports a single-line comment added in a test-only file with a normal commit on its task branch. I’m checking Hive state now before I inspect the exact change and integrate it.
⚙ hive_status 
```

